### PR TITLE
Add type hints across the codebase

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -1,9 +1,12 @@
 # coding=utf-8
+from __future__ import annotations
+
 import datetime
 import json
 import logging
 import re
 import secrets
+from typing import TYPE_CHECKING, Any
 
 from pyradios import RadioBrowser
 
@@ -14,12 +17,16 @@ import util
 from constants import commands
 from constants import tr_cli as tr
 from database import SettingsDatabase, MusicDatabase, Condition
+from media.cache import CachedItemWrapper
 from media.url_from_playlist import get_playlist_info
+
+if TYPE_CHECKING:
+    from mumbleBot import MumbleBot
 
 log = logging.getLogger("bot")
 
 
-def register_all_commands(bot):
+def register_all_commands(bot: MumbleBot) -> None:
     bot.register_command(commands('add_from_shortlist', bot.config), cmd_shortlist)
     bot.register_command(commands('add_tag', bot.config), cmd_add_tag)
     bot.register_command(commands('change_user_password', bot.config), cmd_user_password, no_partial_match=True)
@@ -84,7 +91,7 @@ def register_all_commands(bot):
     # bot.register_command('item', cmd_item, True)
 
 
-def send_multi_lines(bot, lines, text, linebreak="<br />"):
+def send_multi_lines(bot: MumbleBot, lines: list[str], text: Any, linebreak: str = "<br />") -> None:
     global log
 
     msg = ""
@@ -101,7 +108,7 @@ def send_multi_lines(bot, lines, text, linebreak="<br />"):
     bot.send_msg(msg, text)
 
 
-def send_multi_lines_in_channel(bot, lines, linebreak="<br />"):
+def send_multi_lines_in_channel(bot: MumbleBot, lines: list[str], linebreak: str = "<br />") -> None:
     global log
 
     msg = ""
@@ -118,7 +125,7 @@ def send_multi_lines_in_channel(bot, lines, linebreak="<br />"):
     bot.send_channel_msg(msg)
 
 
-def send_item_added_message(bot, wrapper, index, text):
+def send_item_added_message(bot: MumbleBot, wrapper: CachedItemWrapper, index: int, text: Any) -> None:
     if index == bot.playlist.current_index + 1:
         bot.send_msg(tr('file_added', item=wrapper.format_song_string()) +
                      tr('position_in_the_queue', position=tr('next_to_play')), text)
@@ -139,14 +146,14 @@ song_shortlist = []
 
 # ---------------- Commands ------------------
 
-def cmd_joinme(bot, user, text, command, parameter):
+def cmd_joinme(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.mumble.users.myself.move_in(
         bot.mumble.users[text.actor]['channel_id'], token=parameter)
 
 
-def cmd_user_ban(bot, user, text, command, parameter):
+def cmd_user_ban(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if parameter:
@@ -160,7 +167,7 @@ def cmd_user_ban(bot, user, text, command, parameter):
         bot.send_msg(tr("user_ban_list", list=ban_list), text)
 
 
-def cmd_user_unban(bot, user, text, command, parameter):
+def cmd_user_unban(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if parameter and bot.db.has_option("user_ban", parameter):
@@ -168,7 +175,7 @@ def cmd_user_unban(bot, user, text, command, parameter):
         bot.send_msg(tr("user_unban_success", user=parameter), text)
 
 
-def cmd_url_ban(bot, user, text, command, parameter):
+def cmd_url_ban(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     url = util.get_url_from_input(parameter)
@@ -196,7 +203,7 @@ def cmd_url_ban(bot, user, text, command, parameter):
     bot.send_msg(tr("url_ban_success", url=url), text)
 
 
-def cmd_url_ban_list(bot, user, text, command, parameter):
+def cmd_url_ban_list(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     ban_list = "<ul>"
     for i in bot.db.items("url_ban"):
         ban_list += "<li>" + i[0] + "</li>"
@@ -205,7 +212,7 @@ def cmd_url_ban_list(bot, user, text, command, parameter):
     bot.send_msg(tr("url_ban_list", list=ban_list), text)
 
 
-def cmd_url_unban(bot, user, text, command, parameter):
+def cmd_url_unban(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     url = util.get_url_from_input(parameter)
     if url:
         bot.db.remove_option("url_ban", url)
@@ -214,7 +221,7 @@ def cmd_url_unban(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_url_whitelist(bot, user, text, command, parameter):
+def cmd_url_whitelist(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     url = util.get_url_from_input(parameter)
     if url:
         # Unban first
@@ -230,7 +237,7 @@ def cmd_url_whitelist(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_url_whitelist_list(bot, user, text, command, parameter):
+def cmd_url_whitelist_list(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     ban_list = "<ul>"
     for i in bot.db.items("url_whitelist"):
         ban_list += "<li>" + i[0] + "</li>"
@@ -239,7 +246,7 @@ def cmd_url_whitelist_list(bot, user, text, command, parameter):
     bot.send_msg(tr("url_whitelist_list", list=ban_list), text)
 
 
-def cmd_url_unwhitelist(bot, user, text, command, parameter):
+def cmd_url_unwhitelist(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     url = util.get_url_from_input(parameter)
     if url:
         bot.db.remove_option("url_whitelist", url)
@@ -248,7 +255,7 @@ def cmd_url_unwhitelist(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_play(bot, user, text, command, parameter):
+def cmd_play(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     params = parameter.split()
@@ -281,14 +288,14 @@ def cmd_play(bot, user, text, command, parameter):
         bot.send_msg(tr('queue_empty'), text)
 
 
-def cmd_pause(bot, user, text, command, parameter):
+def cmd_pause(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.pause()
     bot.send_channel_msg(tr('paused'))
 
 
-def cmd_play_file(bot, user, text, command, parameter, do_not_refresh_cache=False):
+def cmd_play_file(bot: MumbleBot, user: str, text: Any, command: str, parameter: str, do_not_refresh_cache: bool = False) -> None:
     global log, song_shortlist
 
     # assume parameter is a path
@@ -342,7 +349,7 @@ def cmd_play_file(bot, user, text, command, parameter, do_not_refresh_cache=Fals
         cmd_play_file(bot, user, text, command, parameter, do_not_refresh_cache=True)
 
 
-def cmd_play_file_match(bot, user, text, command, parameter, do_not_refresh_cache=False):
+def cmd_play_file_match(bot: MumbleBot, user: str, text: Any, command: str, parameter: str, do_not_refresh_cache: bool = False) -> None:
     global log
 
     if parameter:
@@ -385,7 +392,7 @@ def cmd_play_file_match(bot, user, text, command, parameter, do_not_refresh_cach
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_play_url(bot, user, text, command, parameter):
+def cmd_play_url(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     url = util.get_url_from_input(parameter)
@@ -403,7 +410,7 @@ def cmd_play_url(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_play_playlist(bot, user, text, command, parameter):
+def cmd_play_playlist(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     offset = 0  # if you want to start the playlist at a specific index
@@ -426,7 +433,7 @@ def cmd_play_playlist(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_play_radio(bot, user, text, command, parameter):
+def cmd_play_radio(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if not parameter:
@@ -453,7 +460,7 @@ def cmd_play_radio(bot, user, text, command, parameter):
             bot.send_msg(tr('bad_url'), text)
 
 
-def cmd_rb_query(bot, user, text, command, parameter):
+def cmd_rb_query(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     log.info('cmd: Querying radio stations')
@@ -511,7 +518,7 @@ def cmd_rb_query(bot, user, text, command, parameter):
                         bot.send_msg('Query result too long to post (> 5000 characters), please try another query.', text)
 
 
-def cmd_rb_play(bot, user, text, command, parameter):
+def cmd_rb_play(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     log.debug('cmd: Play a station by ID')
@@ -552,7 +559,7 @@ yt_last_result = []
 yt_last_page = 0  # TODO: if we keep adding global variables, we need to consider sealing all commands up into classes.
 
 
-def cmd_yt_search(bot, user, text, command, parameter):
+def cmd_yt_search(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log, yt_last_result, yt_last_page, song_shortlist
     item_per_page = 5
 
@@ -596,7 +603,7 @@ def _yt_format_result(results, start, count):
     return msg
 
 
-def cmd_yt_play(bot, user, text, command, parameter):
+def cmd_yt_play(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log, yt_last_result, yt_last_page
 
     if parameter:
@@ -612,14 +619,14 @@ def cmd_yt_play(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_help(bot, user, text, command, parameter):
+def cmd_help(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
     bot.send_msg(tr('help'), text)
     if bot.is_admin(user):
         bot.send_msg(tr('admin_help'), text)
 
 
-def cmd_stop(bot, user, text, command, parameter):
+def cmd_stop(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if bot.config.getboolean("bot", "clear_when_stop_in_oneshot") \
@@ -630,21 +637,21 @@ def cmd_stop(bot, user, text, command, parameter):
     bot.send_msg(tr('stopped'), text)
 
 
-def cmd_clear(bot, user, text, command, parameter):
+def cmd_clear(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.clear()
     bot.send_msg(tr('cleared'), text)
 
 
-def cmd_kill(bot, user, text, command, parameter):
+def cmd_kill(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.pause()
     bot.exit = True
 
 
-def cmd_update(bot, user, text, command, parameter):
+def cmd_update(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if bot.is_admin(user):
@@ -657,7 +664,7 @@ def cmd_update(bot, user, text, command, parameter):
             tr('not_admin'))
 
 
-def cmd_stop_and_getout(bot, user, text, command, parameter):
+def cmd_stop_and_getout(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.stop()
@@ -667,7 +674,7 @@ def cmd_stop_and_getout(bot, user, text, command, parameter):
     bot.join_channel()
 
 
-def cmd_volume(bot, user, text, command, parameter):
+def cmd_volume(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     # The volume is a percentage
@@ -687,7 +694,7 @@ def cmd_volume(bot, user, text, command, parameter):
     else:
         bot.send_msg(tr('current_volume', volume=int(bot.volume_helper.plain_volume_set * 100)), text)
 
-def cmd_max_volume(bot, user, text, command, parameter):
+def cmd_max_volume(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
     
     if parameter and parameter.isdigit() and 0 <= int(parameter) <= 100:
@@ -703,7 +710,7 @@ def cmd_max_volume(bot, user, text, command, parameter):
             max_vol = bot.db.getfloat('bot', 'max_volume') * 100.0
         bot.send_msg(tr('current_max_volume', max=int(max_vol)), text)
         
-def cmd_ducking(bot, user, text, command, parameter):
+def cmd_ducking(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if parameter == "" or parameter == "on":
@@ -723,7 +730,7 @@ def cmd_ducking(bot, user, text, command, parameter):
         bot.send_msg(msg, text)
 
 
-def cmd_ducking_threshold(bot, user, text, command, parameter):
+def cmd_ducking_threshold(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if parameter and parameter.isdigit():
@@ -736,7 +743,7 @@ def cmd_ducking_threshold(bot, user, text, command, parameter):
         bot.send_msg(msg, text)
 
 
-def cmd_ducking_volume(bot, user, text, command, parameter):
+def cmd_ducking_volume(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     # The volume is a percentage
@@ -749,7 +756,7 @@ def cmd_ducking_volume(bot, user, text, command, parameter):
         bot.send_msg(tr('current_ducking_volume', volume=int(bot.volume_helper.plain_ducking_volume_set * 100)), text)
 
 
-def cmd_current_music(bot, user, text, command, parameter):
+def cmd_current_music(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if len(bot.playlist) > 0:
@@ -758,7 +765,7 @@ def cmd_current_music(bot, user, text, command, parameter):
         bot.send_msg(tr('not_playing'), text)
 
 
-def cmd_skip(bot, user, text, command, parameter):
+def cmd_skip(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if not bot.is_pause:
@@ -771,7 +778,7 @@ def cmd_skip(bot, user, text, command, parameter):
         bot.send_msg(tr('queue_empty'), text)
 
 
-def cmd_last(bot, user, text, command, parameter):
+def cmd_last(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if len(bot.playlist) > 0:
@@ -781,7 +788,7 @@ def cmd_last(bot, user, text, command, parameter):
         bot.send_msg(tr('queue_empty'), text)
 
 
-def cmd_remove(bot, user, text, command, parameter):
+def cmd_remove(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     # Allow to remove specific music into the queue with a number
@@ -814,7 +821,7 @@ def cmd_remove(bot, user, text, command, parameter):
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_list_file(bot, user, text, command, parameter):
+def cmd_list_file(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global song_shortlist
 
     files = bot.music_db.query_music(Condition()
@@ -851,7 +858,7 @@ def cmd_list_file(bot, user, text, command, parameter):
         bot.send_msg(msg, text)
 
 
-def cmd_queue(bot, user, text, command, parameter):
+def cmd_queue(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if len(bot.playlist) == 0:
@@ -875,14 +882,14 @@ def cmd_queue(bot, user, text, command, parameter):
         send_multi_lines(bot, msgs, text)
 
 
-def cmd_random(bot, user, text, command, parameter):
+def cmd_random(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     bot.interrupt()
     bot.playlist.randomize()
 
 
-def cmd_repeat(bot, user, text, command, parameter):
+def cmd_repeat(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     repeat = 1
@@ -903,7 +910,7 @@ def cmd_repeat(bot, user, text, command, parameter):
         bot.send_msg(tr("queue_empty"), text)
 
 
-def cmd_mode(bot, user, text, command, parameter):
+def cmd_mode(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if not parameter:
@@ -921,7 +928,7 @@ def cmd_mode(bot, user, text, command, parameter):
             bot.interrupt()
 
 
-def cmd_play_tags(bot, user, text, command, parameter):
+def cmd_play_tags(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     if not parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
         return
@@ -945,7 +952,7 @@ def cmd_play_tags(bot, user, text, command, parameter):
         bot.send_msg(tr("no_file"), text)
 
 
-def cmd_add_tag(bot, user, text, command, parameter):
+def cmd_add_tag(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     params = parameter.split(" ", 1)
@@ -981,7 +988,7 @@ def cmd_add_tag(bot, user, text, command, parameter):
     bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_remove_tag(bot, user, text, command, parameter):
+def cmd_remove_tag(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     params = parameter.split(" ", 1)
@@ -1031,7 +1038,7 @@ def cmd_remove_tag(bot, user, text, command, parameter):
     bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_find_tagged(bot, user, text, command, parameter):
+def cmd_find_tagged(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global song_shortlist
 
     if not parameter:
@@ -1064,7 +1071,7 @@ def cmd_find_tagged(bot, user, text, command, parameter):
         bot.send_msg(tr("no_file"), text)
 
 
-def cmd_search_library(bot, user, text, command, parameter):
+def cmd_search_library(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global song_shortlist
     if not parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
@@ -1111,7 +1118,7 @@ def cmd_search_library(bot, user, text, command, parameter):
         bot.send_msg(tr("no_file"), text)
 
 
-def cmd_shortlist(bot, user, text, command, parameter):
+def cmd_shortlist(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global song_shortlist, log
     if parameter.strip() == "*":
         msgs = [tr('multiple_file_added') + "<ul>"]
@@ -1170,7 +1177,7 @@ def cmd_shortlist(bot, user, text, command, parameter):
     bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_delete_from_library(bot, user, text, command, parameter):
+def cmd_delete_from_library(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global song_shortlist, log
 
     if not bot.config.getboolean("bot", "delete_allowed"):
@@ -1222,7 +1229,7 @@ def cmd_delete_from_library(bot, user, text, command, parameter):
     bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def cmd_drop_database(bot, user, text, command, parameter):
+def cmd_drop_database(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
 
     if bot.is_admin(user):
@@ -1236,7 +1243,7 @@ def cmd_drop_database(bot, user, text, command, parameter):
         bot.mumble.users[text.actor].send_text_message(tr('not_admin'))
 
 
-def cmd_refresh_cache(bot, user, text, command, parameter):
+def cmd_refresh_cache(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     global log
     if bot.is_admin(user):
         bot.cache.build_dir_cache()
@@ -1246,7 +1253,7 @@ def cmd_refresh_cache(bot, user, text, command, parameter):
         bot.mumble.users[text.actor].send_text_message(tr('not_admin'))
 
 
-def cmd_web_access(bot, user, text, command, parameter):
+def cmd_web_access(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     auth_method = bot.config.get("webinterface", "auth_method")
 
     if auth_method == 'token':
@@ -1272,7 +1279,7 @@ def cmd_web_access(bot, user, text, command, parameter):
     bot.send_msg(tr('webpage_address', address=access_address), text)
 
 
-def cmd_user_password(bot, user, text, command, parameter):
+def cmd_user_password(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     if not parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
         return
@@ -1286,7 +1293,7 @@ def cmd_user_password(bot, user, text, command, parameter):
     bot.send_msg(tr('user_password_set'), text)
 
 
-def cmd_web_user_add(bot, user, text, command, parameter):
+def cmd_web_user_add(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     if not parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
         return
@@ -1303,7 +1310,7 @@ def cmd_web_user_add(bot, user, text, command, parameter):
         bot.send_msg(tr('command_disabled', command=command), text)
 
 
-def cmd_web_user_remove(bot, user, text, command, parameter):
+def cmd_web_user_remove(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     if not parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
         return
@@ -1320,7 +1327,7 @@ def cmd_web_user_remove(bot, user, text, command, parameter):
         bot.send_msg(tr('command_disabled', command=command), text)
 
 
-def cmd_web_user_list(bot, user, text, command, parameter):
+def cmd_web_user_list(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     auth_method = bot.config.get("webinterface", "auth_method")
 
     if auth_method == 'password':
@@ -1330,18 +1337,18 @@ def cmd_web_user_list(bot, user, text, command, parameter):
         bot.send_msg(tr('command_disabled', command=command), text)
 
 
-def cmd_version(bot, user, text, command, parameter):
+def cmd_version(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     bot.send_msg(tr('report_version', version=bot.get_version()), text)
 
 
 # Just for debug use
-def cmd_real_time_rms(bot, user, text, command, parameter):
+def cmd_real_time_rms(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     bot._display_rms = not bot._display_rms
 
 
-def cmd_loop_state(bot, user, text, command, parameter):
+def cmd_loop_state(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     print(bot._loop_status)
 
 
-def cmd_item(bot, user, text, command, parameter):
+def cmd_item(bot: MumbleBot, user: str, text: Any, command: str, parameter: str) -> None:
     bot.playlist._debug_print()

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,11 +1,13 @@
 import os
 import json
+from configparser import ConfigParser
+from typing import Any
 
-default_lang_dict = {}
-lang_dict = {}
+default_lang_dict: dict[str, Any] = {}
+lang_dict: dict[str, Any] = {}
 
 
-def load_lang(lang):
+def load_lang(lang: str) -> None:
     global lang_dict, default_lang_dict
     root_dir = os.path.dirname(__file__)
     with open(os.path.join(root_dir, "../lang/en_US.json"), "r") as f:
@@ -14,7 +16,7 @@ def load_lang(lang):
         lang_dict = json.load(f)
 
 
-def tr_cli(option, *argv, **kwargs):
+def tr_cli(option: str, *argv: Any, **kwargs: Any) -> str:
     try:
         if option in lang_dict['cli'] and lang_dict['cli'][option]:
             string = lang_dict['cli'][option]
@@ -25,7 +27,7 @@ def tr_cli(option, *argv, **kwargs):
     return _tr(string, *argv, **kwargs)
 
 
-def tr_web(option, *argv, **kwargs):
+def tr_web(option: str, *argv: Any, **kwargs: Any) -> str:
     try:
         if option in lang_dict['web'] and lang_dict['web'][option]:
             string = lang_dict['web'][option]
@@ -36,7 +38,7 @@ def tr_web(option, *argv, **kwargs):
     return _tr(string, *argv, **kwargs)
 
 
-def _tr(string, *argv, **kwargs):
+def _tr(string: str, *argv: Any, **kwargs: Any) -> str:
     if argv or kwargs:
         try:
             formatted = string.format(*argv, **kwargs)
@@ -53,7 +55,7 @@ def _tr(string, *argv, **kwargs):
         return string
 
 
-def commands(command, config):
+def commands(command: str, config: ConfigParser) -> str:
     try:
         string = config.get("commands", command)
         return string

--- a/src/database.py
+++ b/src/database.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sqlite3
+from typing import Any, Self
 
 log = logging.getLogger("bot")
 
@@ -12,17 +13,16 @@ class DatabaseError(Exception):
 
 
 class Condition:
-    def __init__(self):
-        self.filler = []
+    def __init__(self) -> None:
+        self.filler: list[Any] = []
         self._sql = ""
         self._limit = 0
         self._offset = 0
         self._order_by = ""
-        self._desc = ""
+        self._desc: bool = False
         self.has_regex = False
-        pass
 
-    def sql(self, conn: sqlite3.Connection = None):
+    def sql(self, conn: sqlite3.Connection | None = None) -> str:
         sql = self._sql
         if not self._sql:
             sql = "1"
@@ -40,13 +40,13 @@ class Condition:
         return sql
 
     @staticmethod
-    def _regexp(expr, item):
+    def _regexp(expr: str, item: str | None) -> bool:
         if not item:
             return False
         reg = re.compile(expr)
         return reg.search(item) is not None
 
-    def or_equal(self, column, equals_to, case_sensitive=True):
+    def or_equal(self, column: str, equals_to: str, case_sensitive: bool = True) -> Self:
         if not case_sensitive:
             column = f"LOWER({column})"
             equals_to = equals_to.lower()
@@ -60,7 +60,7 @@ class Condition:
 
         return self
 
-    def and_equal(self, column, equals_to, case_sensitive=True):
+    def and_equal(self, column: str, equals_to: str, case_sensitive: bool = True) -> Self:
         if not case_sensitive:
             column = f"LOWER({column})"
             equals_to = equals_to.lower()
@@ -74,7 +74,7 @@ class Condition:
 
         return self
 
-    def or_like(self, column, equals_to, case_sensitive=True):
+    def or_like(self, column: str, equals_to: str, case_sensitive: bool = True) -> Self:
         if not case_sensitive:
             column = f"LOWER({column})"
             equals_to = equals_to.lower()
@@ -88,7 +88,7 @@ class Condition:
 
         return self
 
-    def and_like(self, column, equals_to, case_sensitive=True):
+    def and_like(self, column: str, equals_to: str, case_sensitive: bool = True) -> Self:
         if not case_sensitive:
             column = f"LOWER({column})"
             equals_to = equals_to.lower()
@@ -102,7 +102,7 @@ class Condition:
 
         return self
 
-    def and_regexp(self, column, regex):
+    def and_regexp(self, column: str, regex: str) -> Self:
         self.has_regex = True
 
         if self._sql:
@@ -114,7 +114,7 @@ class Condition:
 
         return self
 
-    def or_regexp(self, column, regex):
+    def or_regexp(self, column: str, regex: str) -> Self:
         self.has_regex = True
 
         if self._sql:
@@ -126,7 +126,7 @@ class Condition:
 
         return self
 
-    def or_sub_condition(self, sub_condition):
+    def or_sub_condition(self, sub_condition: Self) -> Self:
         if sub_condition.has_regex:
             self.has_regex = True
 
@@ -138,7 +138,7 @@ class Condition:
 
         return self
 
-    def or_not_sub_condition(self, sub_condition):
+    def or_not_sub_condition(self, sub_condition: Self) -> Self:
         if sub_condition.has_regex:
             self.has_regex = True
 
@@ -150,7 +150,7 @@ class Condition:
 
         return self
 
-    def and_sub_condition(self, sub_condition):
+    def and_sub_condition(self, sub_condition: Self) -> Self:
         if sub_condition.has_regex:
             self.has_regex = True
 
@@ -162,7 +162,7 @@ class Condition:
 
         return self
 
-    def and_not_sub_condition(self, sub_condition):
+    def and_not_sub_condition(self, sub_condition: Self) -> Self:
         if sub_condition.has_regex:
             self.has_regex = True
 
@@ -174,17 +174,17 @@ class Condition:
 
         return self
 
-    def limit(self, limit):
+    def limit(self, limit: int) -> Self:
         self._limit = limit
 
         return self
 
-    def offset(self, offset):
+    def offset(self, offset: int) -> Self:
         self._offset = offset
 
         return self
 
-    def order_by(self, order_by, desc=False):
+    def order_by(self, order_by: str, desc: bool = False) -> Self:
         self._order_by = order_by
         self._desc = desc
 
@@ -196,10 +196,10 @@ MUSIC_DB_VERSION = 4
 
 
 class SettingsDatabase:
-    def __init__(self, db_path):
+    def __init__(self, db_path: str) -> None:
         self.db_path = db_path
 
-    def get(self, section, option, **kwargs):
+    def get(self, section: str, option: str, **kwargs: Any) -> str:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         result = cursor.execute("SELECT value FROM botamusique WHERE section=? AND option=?",
@@ -214,16 +214,16 @@ class SettingsDatabase:
             else:
                 raise DatabaseError("Item not found")
 
-    def getboolean(self, section, option, **kwargs):
+    def getboolean(self, section: str, option: str, **kwargs: Any) -> bool:
         return bool(int(self.get(section, option, **kwargs)))
 
-    def getfloat(self, section, option, **kwargs):
+    def getfloat(self, section: str, option: str, **kwargs: Any) -> float:
         return float(self.get(section, option, **kwargs))
 
-    def getint(self, section, option, **kwargs):
+    def getint(self, section: str, option: str, **kwargs: Any) -> int:
         return int(self.get(section, option, **kwargs))
 
-    def set(self, section, option, value):
+    def set(self, section: str, option: str, value: str) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("INSERT OR REPLACE INTO botamusique (section, option, value) "
@@ -231,7 +231,7 @@ class SettingsDatabase:
         conn.commit()
         conn.close()
 
-    def has_option(self, section, option):
+    def has_option(self, section: str, option: str) -> bool:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         result = cursor.execute("SELECT value FROM botamusique WHERE section=? AND option=?",
@@ -242,21 +242,21 @@ class SettingsDatabase:
         else:
             return False
 
-    def remove_option(self, section, option):
+    def remove_option(self, section: str, option: str) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("DELETE FROM botamusique WHERE section=? AND option=?", (section, option))
         conn.commit()
         conn.close()
 
-    def remove_section(self, section):
+    def remove_section(self, section: str) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("DELETE FROM botamusique WHERE section=?", (section,))
         conn.commit()
         conn.close()
 
-    def items(self, section):
+    def items(self, section: str) -> list[tuple[str, str]]:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         results = cursor.execute("SELECT option, value FROM botamusique WHERE section=?", (section,)).fetchall()
@@ -267,7 +267,7 @@ class SettingsDatabase:
         else:
             return []
 
-    def drop_table(self):
+    def drop_table(self) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("DROP TABLE botamusique")
@@ -275,10 +275,10 @@ class SettingsDatabase:
 
 
 class MusicDatabase:
-    def __init__(self, db_path):
+    def __init__(self, db_path: str) -> None:
         self.db_path = db_path
 
-    def insert_music(self, music_dict, _conn=None):
+    def insert_music(self, music_dict: dict[str, Any], _conn: sqlite3.Connection | None = None) -> None:
         conn = sqlite3.connect(self.db_path) if _conn is None else _conn
         cursor = conn.cursor()
 
@@ -327,7 +327,7 @@ class MusicDatabase:
             conn.commit()
             conn.close()
 
-    def query_music_ids(self, condition: Condition):
+    def query_music_ids(self, condition: Condition) -> list[str]:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         results = cursor.execute("SELECT id FROM music WHERE id != 'info' AND %s" %
@@ -335,7 +335,7 @@ class MusicDatabase:
         conn.close()
         return list(map(lambda i: i[0], results))
 
-    def query_all_paths(self):
+    def query_all_paths(self) -> list[str]:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         results = cursor.execute("SELECT path FROM music WHERE id != 'info' AND type = 'file'").fetchall()
@@ -347,7 +347,7 @@ class MusicDatabase:
 
         return paths
 
-    def query_all_tags(self):
+    def query_all_tags(self) -> list[str]:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         results = cursor.execute("SELECT tags FROM music WHERE id != 'info'").fetchall()
@@ -359,7 +359,7 @@ class MusicDatabase:
         conn.close()
         return tags
 
-    def query_music_count(self, condition: Condition):
+    def query_music_count(self, condition: Condition) -> int:
         filler = condition.filler
 
         conn = sqlite3.connect(self.db_path)
@@ -371,7 +371,7 @@ class MusicDatabase:
 
         return results[0][0]
 
-    def query_music(self, condition: Condition, _conn=None):
+    def query_music(self, condition: Condition, _conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
         filler = condition.filler
 
         conn = sqlite3.connect(self.db_path) if _conn is None else _conn
@@ -384,7 +384,7 @@ class MusicDatabase:
 
         return self._result_to_dict(results)
 
-    def _query_music_by_plain_sql_cond(self, sql_cond, _conn=None):
+    def _query_music_by_plain_sql_cond(self, sql_cond: str, _conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
         conn = sqlite3.connect(self.db_path) if _conn is None else _conn
         cursor = conn.cursor()
         results = cursor.execute("SELECT id, type, title, metadata, tags, path, keywords FROM music "
@@ -394,14 +394,14 @@ class MusicDatabase:
 
         return self._result_to_dict(results)
 
-    def query_music_by_id(self, _id, _conn=None):
+    def query_music_by_id(self, _id: str, _conn: sqlite3.Connection | None = None) -> dict[str, Any] | None:
         results = self.query_music(Condition().and_equal("id", _id), _conn)
         if results:
             return results[0]
         else:
             return None
 
-    def query_music_by_keywords(self, keywords, _conn=None):
+    def query_music_by_keywords(self, keywords: list[str], _conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
         condition = Condition()
 
         for keyword in keywords:
@@ -409,7 +409,7 @@ class MusicDatabase:
 
         return self.query_music(condition, _conn)
 
-    def query_music_by_tags(self, tags, _conn=None):
+    def query_music_by_tags(self, tags: list[str], _conn: sqlite3.Connection | None = None) -> list[dict[str, Any]]:
         condition = Condition()
 
         for tag in tags:
@@ -417,7 +417,7 @@ class MusicDatabase:
 
         return self.query_music(condition, _conn)
 
-    def manage_special_tags(self):
+    def manage_special_tags(self) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("UPDATE music SET tags=REPLACE(tags, 'recent added,', '') WHERE tags LIKE '%recent added,%' "
@@ -427,7 +427,7 @@ class MusicDatabase:
         conn.commit()
         conn.close()
 
-    def query_tags(self, condition: Condition):
+    def query_tags(self, condition: Condition) -> dict[str, list[str]]:
         # TODO: Can we keep a index of tags?
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
@@ -445,7 +445,7 @@ class MusicDatabase:
 
         return lookup
 
-    def query_random_music(self, count, condition: Condition = None):
+    def query_random_music(self, count: int, condition: Condition | None = None) -> list[dict[str, Any]]:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         results = []
@@ -461,7 +461,7 @@ class MusicDatabase:
 
         return self._result_to_dict(results)
 
-    def _result_to_dict(self, results):
+    def _result_to_dict(self, results: list[Any]) -> list[dict[str, Any]]:
         if len(results) > 0:
             music_dicts = []
             for result in results:
@@ -479,7 +479,7 @@ class MusicDatabase:
         else:
             return []
 
-    def delete_music(self, condition: Condition):
+    def delete_music(self, condition: Condition) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("DELETE FROM music "
@@ -487,7 +487,7 @@ class MusicDatabase:
         conn.commit()
         conn.close()
 
-    def drop_table(self):
+    def drop_table(self) -> None:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("DROP TABLE music")
@@ -507,11 +507,11 @@ class DatabaseMigration:
                                          }
 
 
-    def migrate(self):
+    def migrate(self) -> None:
         self.settings_database_migrate()
         self.music_database_migrate()
 
-    def settings_database_migrate(self):
+    def settings_database_migrate(self) -> None:
         conn = sqlite3.connect(self.settings_db.db_path)
         cursor = conn.cursor()
         if self.has_table('botamusique', conn):
@@ -542,7 +542,7 @@ class DatabaseMigration:
         conn.commit()
         conn.close()
 
-    def music_database_migrate(self):
+    def music_database_migrate(self) -> None:
         conn = sqlite3.connect(self.music_db.db_path)
         cursor = conn.cursor()
         if self.has_table('music', conn):
@@ -571,14 +571,14 @@ class DatabaseMigration:
         conn.commit()
         conn.close()
 
-    def has_table(self, table, conn):
+    def has_table(self, table: str, conn: sqlite3.Connection) -> bool:
         cursor = conn.cursor()
         tables = cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?;", (table,)).fetchall()
         if len(tables) == 0:
             return False
         return True
 
-    def create_settings_table_version_2(self, conn):
+    def create_settings_table_version_2(self, conn: sqlite3.Connection) -> int:
         cursor = conn.cursor()
         cursor.execute("CREATE TABLE IF NOT EXISTS botamusique ("
                        "section TEXT, "
@@ -591,7 +591,7 @@ class DatabaseMigration:
 
         return 1
 
-    def create_music_table_version_1(self, conn):
+    def create_music_table_version_1(self, conn: sqlite3.Connection) -> None:
         cursor = conn.cursor()
 
         cursor.execute("CREATE TABLE music ("
@@ -609,17 +609,17 @@ class DatabaseMigration:
 
         conn.commit()
 
-    def create_music_table_version_4(self, conn):
+    def create_music_table_version_4(self, conn: sqlite3.Connection) -> None:
         self.create_music_table_version_1(conn)
 
-    def settings_table_migrate_from_0_to_1(self, conn):
+    def settings_table_migrate_from_0_to_1(self, conn: sqlite3.Connection) -> int:
         cursor = conn.cursor()
         cursor.execute("DROP TABLE botamusique")
         conn.commit()
         self.create_settings_table_version_2(conn)
         return 2  # return new version number
 
-    def settings_table_migrate_from_1_to_2(self, conn):
+    def settings_table_migrate_from_1_to_2(self, conn: sqlite3.Connection) -> int:
         cursor = conn.cursor()
         # move music database into a separated file
         if self.has_table('music', conn) and not os.path.exists(self.music_db.db_path):
@@ -640,7 +640,7 @@ class DatabaseMigration:
                        "WHERE section='bot' AND option='db_version'")
         return 2  # return new version number
 
-    def music_table_migrate_from_0_to_1(self, conn):
+    def music_table_migrate_from_0_to_1(self, conn: sqlite3.Connection) -> int:
         cursor = conn.cursor()
         cursor.execute("ALTER TABLE music RENAME TO music_old")
         conn.commit()
@@ -654,7 +654,7 @@ class DatabaseMigration:
 
         return 1  # return new version number
 
-    def music_table_migrate_from_1_to_2(self, conn):
+    def music_table_migrate_from_1_to_2(self, conn: sqlite3.Connection) -> int:
         items_to_update = self.music_db.query_music(Condition(), conn)
         for item in items_to_update:
             item['keywords'] = item['title']
@@ -672,7 +672,7 @@ class DatabaseMigration:
 
         return 2  # return new version number
 
-    def music_table_migrate_from_2_to_4(self, conn):
+    def music_table_migrate_from_2_to_4(self, conn: sqlite3.Connection) -> int:
         items_to_update = self.music_db.query_music(Condition(), conn)
         for item in items_to_update:
             if 'duration' not in item:

--- a/src/interface.py
+++ b/src/interface.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+from __future__ import annotations
+
 import errno
 import json
 import logging
@@ -9,6 +11,7 @@ import sqlite3
 import time
 from functools import wraps
 from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable
 
 from flask import Flask, render_template, request, redirect, send_file, Response, jsonify, abort, session
 
@@ -21,10 +24,13 @@ from media.radio import RadioItem
 from media.url import URLItem
 from media.url_from_playlist import PlaylistURLItem
 
-_bot = None
+if TYPE_CHECKING:
+    from mumbleBot import MumbleBot
+
+_bot: MumbleBot | None = None
 
 
-def set_bot(bot):
+def set_bot(bot: MumbleBot) -> None:
     global _bot
     _bot = bot
 
@@ -47,10 +53,10 @@ class ReverseProxied(object):
     :param app: the WSGI application
     """
 
-    def __init__(self, app):
+    def __init__(self, app: Any) -> None:
         self.app = app
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ: dict[str, Any], start_response: Any) -> Any:
         script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
         if script_name:
             environ['SCRIPT_NAME'] = script_name
@@ -78,7 +84,7 @@ log = logging.getLogger("bot")
 user = 'Remote Control'
 
 
-def init_proxy():
+def init_proxy() -> None:
     global web
     if _bot.is_proxied:
         web.wsgi_app = ReverseProxied(web.wsgi_app)
@@ -87,7 +93,7 @@ def init_proxy():
 # https://stackoverflow.com/questions/29725217/password-protect-one-webpage-in-flask-app
 
 
-def check_auth(username, password):
+def check_auth(username: str, password: str) -> bool:
     """This function is called to check if a username /
     password combination is valid.
     """
@@ -105,7 +111,7 @@ def check_auth(username, password):
     return False
 
 
-def authenticate():
+def authenticate() -> Response:
     """Sends a 401 response that enables basic auth"""
     global log
     return Response('Could not verify your access level for that URL.\n'
@@ -117,7 +123,7 @@ bad_access_count = {}
 banned_ip = []
 
 
-def requires_auth(f):
+def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
     def decorated(*args, **kwargs):
         global log, user, bad_access_count, banned_ip

--- a/src/main.py
+++ b/src/main.py
@@ -19,7 +19,7 @@ from media.cache import MusicCache
 from mumbleBot import MumbleBot, start_web_interface
 
 
-def main():
+def main() -> None:
     # Set defaults from environment variables
     env_config: str = os.getenv('BAM_CONFIG_FILE', 'configuration.ini')
     env_db: str | None = os.getenv('BAM_DB')

--- a/src/media/cache.py
+++ b/src/media/cache.py
@@ -2,8 +2,10 @@ import logging
 import magic
 import os
 import threading
+from configparser import ConfigParser
+from typing import Any
 
-from database import MusicDatabase, Condition
+from database import MusicDatabase, Condition, SettingsDatabase
 from media.file import FileItem
 from media.item import BaseItem
 from media.radio import RadioItem
@@ -29,7 +31,7 @@ def solve_filepath(path: str) -> str:
 
 
 class MusicCache(dict):
-    def __init__(self, music_db: MusicDatabase, settings_db, config, music_folder: str):
+    def __init__(self, music_db: MusicDatabase, settings_db: SettingsDatabase, config: ConfigParser, music_folder: str) -> None:
         super().__init__()
         self.music_db = music_db
         self.settings_db = settings_db
@@ -39,7 +41,7 @@ class MusicCache(dict):
         self.log = logging.getLogger("bot")
         self.dir_lock = threading.Lock()
 
-    def get_item_by_id(self, id):
+    def get_item_by_id(self, id: str) -> BaseItem | None:
         if id in self:
             return self[id]
 
@@ -52,7 +54,7 @@ class MusicCache(dict):
         else:
             return None
 
-    def get_item(self, **kwargs):
+    def get_item(self, **kwargs: Any) -> BaseItem:
         # kwargs should provide type and other parameters to build the item if not in the library.
         item_type = kwargs['type']
 
@@ -104,7 +106,7 @@ class MusicCache(dict):
 
         return self[id]
 
-    def get_items_by_tags(self, tags):
+    def get_items_by_tags(self, tags: list[str]) -> list[BaseItem]:
         music_dicts = self.music_db.query_music_by_tags(tags)
         items = []
         if music_dicts:
@@ -115,7 +117,7 @@ class MusicCache(dict):
 
         return items
 
-    def fetch(self, id):
+    def fetch(self, id: str) -> BaseItem | None:
         music_dict = self.music_db.query_music_by_id(id)
         if music_dict:
             self[id] = self.dict_to_item(music_dict)
@@ -123,7 +125,7 @@ class MusicCache(dict):
         else:
             return None
 
-    def dict_to_item(self, d: dict) -> BaseItem:
+    def dict_to_item(self, d: dict[str, Any]) -> BaseItem:
         match d['type']:
             case 'file':
                 return FileItem.from_dict(d, self.music_folder)
@@ -136,15 +138,15 @@ class MusicCache(dict):
             case _:
                 raise ValueError(f"Unknown item type: {d['type']}")
 
-    def dicts_to_items(self, dicts: list) -> list:
+    def dicts_to_items(self, dicts: list[dict[str, Any]]) -> list[BaseItem]:
         return [self.dict_to_item(d) for d in dicts]
 
-    def save(self, id):
+    def save(self, id: str) -> None:
         self.log.debug("library: music save into database: %s" % self[id].format_debug_string())
         self.music_db.insert_music(self[id].to_dict())
         self.music_db.manage_special_tags()
 
-    def free_and_delete(self, id):
+    def free_and_delete(self, id: str) -> None:
         item = self.get_item_by_id(id)
         if item:
             self.log.debug("library: DELETE item from the database: %s" % item.format_debug_string())
@@ -157,16 +159,16 @@ class MusicCache(dict):
                 del self[item.id]
             self.music_db.delete_music(Condition().and_equal("id", item.id))
 
-    def free(self, id):
+    def free(self, id: str) -> None:
         if id in self:
             self.log.debug("library: cache freed for item: %s" % self[id].format_debug_string())
             del self[id]
 
-    def free_all(self):
+    def free_all(self) -> None:
         self.log.debug("library: all cache freed")
         self.clear()
 
-    def build_dir_cache(self):
+    def build_dir_cache(self) -> None:
         self.dir_lock.acquire()
         self.log.info("library: rebuild directory cache")
         files = self.get_recursive_file_list_sorted(self.music_folder)
@@ -190,7 +192,7 @@ class MusicCache(dict):
         self.music_db.manage_special_tags()
         self.dir_lock.release()
 
-    def get_recursive_file_list_sorted(self, path):
+    def get_recursive_file_list_sorted(self, path: str) -> list[str]:
         filelist = []
 
         if not os.access(path, os.R_OK):
@@ -223,44 +225,44 @@ class MusicCache(dict):
     # Cached wrapper helpers
     # -------------------------
 
-    def get_cached_wrapper(self, item, user):
+    def get_cached_wrapper(self, item: BaseItem | None, user: str) -> 'CachedItemWrapper | None':
         if item:
             self[item.id] = item
             return CachedItemWrapper(self, item.id, item.type, user)
         return None
 
-    def get_cached_wrappers(self, items, user):
+    def get_cached_wrappers(self, items: list[BaseItem], user: str) -> 'list[CachedItemWrapper]':
         wrappers = []
         for item in items:
             if item:
                 wrappers.append(self.get_cached_wrapper(item, user))
         return wrappers
 
-    def get_cached_wrapper_from_scrap(self, **kwargs):
+    def get_cached_wrapper_from_scrap(self, **kwargs: Any) -> 'CachedItemWrapper':
         item = self.get_item(**kwargs)
         if 'user' not in kwargs:
             raise KeyError("Which user added this song?")
         return CachedItemWrapper(self, item.id, kwargs['type'], kwargs['user'])
 
-    def get_cached_wrapper_from_dict(self, dict_from_db, user):
+    def get_cached_wrapper_from_dict(self, dict_from_db: dict[str, Any] | None, user: str) -> 'CachedItemWrapper | None':
         if dict_from_db:
             item = self.dict_to_item(dict_from_db)
             return self.get_cached_wrapper(item, user)
         return None
 
-    def get_cached_wrappers_from_dicts(self, dicts_from_db, user):
+    def get_cached_wrappers_from_dicts(self, dicts_from_db: list[dict[str, Any]], user: str) -> 'list[CachedItemWrapper]':
         items = []
         for dict_from_db in dicts_from_db:
             if dict_from_db:
                 items.append(self.get_cached_wrapper_from_dict(dict_from_db, user))
         return items
 
-    def get_cached_wrapper_by_id(self, id, user):
+    def get_cached_wrapper_by_id(self, id: str, user: str) -> 'CachedItemWrapper | None':
         item = self.get_item_by_id(id)
         if item:
             return CachedItemWrapper(self, item.id, item.type, user)
 
-    def get_cached_wrappers_by_tags(self, tags, user):
+    def get_cached_wrappers_by_tags(self, tags: list[str], user: str) -> 'list[CachedItemWrapper]':
         items = self.get_items_by_tags(tags)
         ret = []
         for item in items:
@@ -269,7 +271,7 @@ class MusicCache(dict):
 
 
 class CachedItemWrapper:
-    def __init__(self, lib, id, type, user):
+    def __init__(self, lib: MusicCache, id: str, type: str, user: str) -> None:
         self.lib = lib
         self.id = id
         self.user = user
@@ -277,69 +279,69 @@ class CachedItemWrapper:
         self.log = logging.getLogger("bot")
         self.version = 0
 
-    def item(self):
+    def item(self) -> BaseItem:
         if self.id in self.lib:
             return self.lib[self.id]
         else:
             raise ItemNotCachedError(f"Uncached item of id {self.id}, type {self.type}.")
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         dict = self.item().to_dict()
         dict['user'] = self.user
         return dict
 
-    def validate(self):
+    def validate(self) -> bool:
         ret = self.item().validate()
         if ret and self.item().version > self.version:
             self.version = self.item().version
             self.lib.save(self.id)
         return ret
 
-    def prepare(self):
+    def prepare(self) -> bool:
         ret = self.item().prepare()
         if ret and self.item().version > self.version:
             self.version = self.item().version
             self.lib.save(self.id)
         return ret
 
-    def uri(self):
+    def uri(self) -> str:
         return self.item().uri()
 
-    def add_tags(self, tags):
+    def add_tags(self, tags: list[str]) -> None:
         self.item().add_tags(tags)
         if self.item().version > self.version:
             self.version = self.item().version
             self.lib.save(self.id)
 
-    def remove_tags(self, tags):
+    def remove_tags(self, tags: list[str]) -> None:
         self.item().remove_tags(tags)
         if self.item().version > self.version:
             self.version = self.item().version
             self.lib.save(self.id)
 
-    def clear_tags(self):
+    def clear_tags(self) -> None:
         self.item().clear_tags()
         if self.item().version > self.version:
             self.version = self.item().version
             self.lib.save(self.id)
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return self.item().is_ready()
 
-    def is_failed(self):
+    def is_failed(self) -> bool:
         return self.item().is_failed()
 
-    def format_current_playing(self):
+    def format_current_playing(self) -> str:
         return self.item().format_current_playing(self.user)
 
-    def format_song_string(self):
+    def format_song_string(self) -> str:
         return self.item().format_song_string(self.user)
 
-    def format_title(self):
+    def format_title(self) -> str:
         return self.item().format_title()
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return self.item().format_debug_string()
 
-    def display_type(self):
+    def display_type(self) -> str:
         return self.item().display_type()

--- a/src/media/file.py
+++ b/src/media/file.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import os
 from io import BytesIO
+from typing import Any
 
 import mutagen
 from PIL import Image
@@ -39,7 +40,7 @@ class FileItem(BaseItem):
         self.keywords = self.title + " " + self.artist
 
     @classmethod
-    def from_dict(cls, d: dict, music_folder: str) -> 'FileItem':
+    def from_dict(cls, d: dict[str, Any], music_folder: str) -> 'FileItem':
         instance = cls.__new__(cls)
         BaseItem.__init__(instance)
         instance._load_base_from_dict(d)
@@ -57,13 +58,13 @@ class FileItem(BaseItem):
     def generate_id(path: str) -> str:
         return hashlib.md5(path.encode()).hexdigest()
 
-    def uri(self):
+    def uri(self) -> str:
         return self.music_folder + self.path if self.path[0] != "/" else self.path
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return True
 
-    def validate(self):
+    def validate(self) -> bool:
         if not os.path.exists(self.uri()):
             self.log.info(
                 "file: music file missed for %s" % self.format_debug_string())
@@ -75,7 +76,7 @@ class FileItem(BaseItem):
         self.ready = "yes"
         return True
 
-    def _get_info_from_tag(self):
+    def _get_info_from_tag(self) -> None:
         path, file_name_ext = os.path.split(self.uri())
         file_name, ext = os.path.splitext(file_name_ext)
 
@@ -148,14 +149,14 @@ class FileItem(BaseItem):
             self.title = file_name
 
     @staticmethod
-    def _prepare_thumbnail(im):
+    def _prepare_thumbnail(im: Image.Image) -> str:
         im.thumbnail((100, 100), Image.LANCZOS)
         buffer = BytesIO()
         im = im.convert('RGB')
         im.save(buffer, format="JPEG")
         return base64.b64encode(buffer.getvalue()).decode('utf-8')
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         dict = super().to_dict()
         dict['type'] = 'file'
         dict['path'] = self.path
@@ -164,20 +165,20 @@ class FileItem(BaseItem):
         dict['thumbnail'] = self.thumbnail
         return dict
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return "[file] {descrip} ({path})".format(
             descrip=self.format_title(),
             path=self.path
         )
 
-    def format_song_string(self, user):
+    def format_song_string(self, user: str) -> str:
         return tr("file_item",
                   title=self.title,
                   artist=self.artist if self.artist else '??',
                   user=user
                   )
 
-    def format_current_playing(self, user):
+    def format_current_playing(self, user: str) -> str:
         display = tr("now_playing", item=self.format_song_string(user))
         if self.thumbnail:
             thumbnail_html = '<img width="80" src="data:image/jpge;base64,' + \
@@ -186,12 +187,12 @@ class FileItem(BaseItem):
 
         return display
 
-    def format_title(self):
+    def format_title(self) -> str:
         title = self.title if self.title else self.path
         if self.artist:
             return self.artist + " - " + title
         else:
             return title
 
-    def display_type(self):
+    def display_type(self) -> str:
         return tr("file")

--- a/src/media/item.py
+++ b/src/media/item.py
@@ -1,30 +1,31 @@
 import logging
+from typing import Any
 
 
 class ValidationFailedError(Exception):
-    def __init__(self, msg=None):
+    def __init__(self, msg: str | None = None) -> None:
         self.msg = msg
 
 
 class PreparationFailedError(Exception):
-    def __init__(self, msg=None):
+    def __init__(self, msg: str | None = None) -> None:
         self.msg = msg
 
 
 class BaseItem:
-    def __init__(self):
+    def __init__(self) -> None:
         self.log = logging.getLogger("bot")
         self.type = "base"
         self.id = ""
         self.title = ""
         self.path = ""
-        self.tags = []
+        self.tags: list[str] = []
         self.keywords = ""
         self.duration = 0
         self.version = 0  # if version increase, wrapper will re-save this item
         self.ready = "pending"  # pending - is_valid() -> validated - prepare() -> yes, failed
 
-    def _load_base_from_dict(self, d: dict):
+    def _load_base_from_dict(self, d: dict[str, Any]) -> None:
         self.id = d['id']
         self.ready = d['ready']
         self.tags = d['tags']
@@ -33,54 +34,54 @@ class BaseItem:
         self.keywords = d['keywords']
         self.duration = d['duration']
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return True if self.ready == "yes" else False
 
-    def is_failed(self):
+    def is_failed(self) -> bool:
         return True if self.ready == "failed" else False
 
-    def validate(self):
+    def validate(self) -> None:
         raise ValidationFailedError(None)
 
-    def uri(self):
-        raise
+    def uri(self) -> str:
+        raise NotImplementedError
 
-    def prepare(self):
+    def prepare(self) -> bool:
         return True
 
-    def add_tags(self, tags):
+    def add_tags(self, tags: list[str]) -> None:
         for tag in tags:
             if tag and tag not in self.tags:
                 self.tags.append(tag)
                 self.version += 1
 
-    def remove_tags(self, tags):
+    def remove_tags(self, tags: list[str]) -> None:
         for tag in tags:
             if tag in self.tags:
                 self.tags.remove(tag)
                 self.version += 1
 
-    def clear_tags(self):
+    def clear_tags(self) -> None:
         if len(self.tags) > 0:
             self.tags = []
             self.version += 1
 
-    def format_song_string(self, user):
+    def format_song_string(self, user: str) -> str:
         return self.id
 
-    def format_current_playing(self, user):
+    def format_current_playing(self, user: str) -> str:
         return self.id
 
-    def format_title(self):
+    def format_title(self) -> str:
         return self.title
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return self.id
 
-    def display_type(self):
+    def display_type(self) -> str:
         return ""
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         return {"type": self.type,
                 "id": self.id,
                 "ready": self.ready,

--- a/src/media/playlist.py
+++ b/src/media/playlist.py
@@ -3,13 +3,17 @@ import logging
 import random
 import threading
 import time
+from configparser import ConfigParser
+from typing import Callable, Any, Self
 
-from database import Condition
-from media.cache import CachedItemWrapper, ItemNotCachedError
+from database import Condition, MusicDatabase, SettingsDatabase
+from media.cache import CachedItemWrapper, ItemNotCachedError, MusicCache
 from media.item import ValidationFailedError
 
+SendMsgCallback = Callable[[str], None]
 
-def get_playlist(mode, cache, settings_db, music_db, config, send_channel_msg, _list=None, _index=None):
+
+def get_playlist(mode: str, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback, _list: 'BasePlaylist | None' = None, _index: int | None = None) -> 'BasePlaylist':
     index = -1
     if _list and _index is None:
         index = _list.current_index
@@ -36,7 +40,7 @@ def get_playlist(mode, cache, settings_db, music_db, config, send_channel_msg, _
 
 
 class BasePlaylist(list):
-    def __init__(self, cache, settings_db, music_db, config, send_channel_msg=None):
+    def __init__(self, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback | None = None) -> None:
         super().__init__()
         self.cache = cache
         self.settings_db = settings_db
@@ -51,10 +55,10 @@ class BasePlaylist(list):
         self.validating_thread_lock = threading.Lock()
         self.playlist_lock = threading.RLock()
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return True if len(self) == 0 else False
 
-    def from_list(self, _list, current_index):
+    def from_list(self, _list: list[CachedItemWrapper], current_index: int) -> Self:
         self.version += 1
         super().clear()
         self.extend(_list)
@@ -62,7 +66,7 @@ class BasePlaylist(list):
 
         return self
 
-    def append(self, item: CachedItemWrapper):
+    def append(self, item: CachedItemWrapper) -> CachedItemWrapper:
         with self.playlist_lock:
             self.version += 1
             super().append(item)
@@ -72,7 +76,7 @@ class BasePlaylist(list):
 
         return item
 
-    def insert(self, index, item):
+    def insert(self, index: int, item: CachedItemWrapper) -> CachedItemWrapper:
         with self.playlist_lock:
             self.version += 1
             if index == -1:
@@ -89,7 +93,7 @@ class BasePlaylist(list):
 
         return item
 
-    def extend(self, items):
+    def extend(self, items: list[CachedItemWrapper]) -> list[CachedItemWrapper]:
         with self.playlist_lock:
             self.version += 1
             super().extend(items)
@@ -98,7 +102,7 @@ class BasePlaylist(list):
         self.async_validate()
         return items
 
-    def next(self):
+    def next(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) == 0:
                 return False
@@ -109,22 +113,22 @@ class BasePlaylist(list):
             else:
                 return False
 
-    def point_to(self, index):
+    def point_to(self, index: int) -> None:
         with self.playlist_lock:
             if -1 <= index < len(self):
                 self.current_index = index
 
-    def find(self, id):
+    def find(self, id: str) -> int | None:
         with self.playlist_lock:
             for index, wrapper in enumerate(self):
                 if wrapper.item.id == id:
                     return index
         return None
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: int) -> CachedItemWrapper | bool:
         return self.remove(key)
 
-    def remove(self, index):
+    def remove(self, index: int) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             self.version += 1
             if index > len(self) - 1:
@@ -146,7 +150,7 @@ class BasePlaylist(list):
             self.cache.free(removed.id)
         return removed
 
-    def remove_by_id(self, id):
+    def remove_by_id(self, id: str) -> None:
         to_be_removed = []
         for index, wrapper in enumerate(self):
             if wrapper.id == id:
@@ -158,34 +162,34 @@ class BasePlaylist(list):
         for index in to_be_removed:
             self.remove(index)
 
-    def current_item(self):
+    def current_item(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) == 0:
                 return False
 
             return self[self.current_index]
 
-    def next_index(self):
+    def next_index(self) -> int | bool:
         with self.playlist_lock:
             if self.current_index < len(self) - 1:
                 return self.current_index + 1
 
         return False
 
-    def next_item(self):
+    def next_item(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if self.current_index < len(self) - 1:
                 return self[self.current_index + 1]
 
         return False
 
-    def randomize(self):
+    def randomize(self) -> None:
         with self.playlist_lock:
             random.shuffle(self)
             self.current_index = -1
             self.version += 1
 
-    def clear(self):
+    def clear(self) -> None:
         with self.playlist_lock:
             self.version += 1
             self.current_index = -1
@@ -193,7 +197,7 @@ class BasePlaylist(list):
 
         self.cache.free_all()
 
-    def save(self):
+    def save(self) -> None:
         with self.playlist_lock:
             self.settings_db.remove_section("playlist_item")
             assert self.current_index is not None
@@ -202,7 +206,7 @@ class BasePlaylist(list):
             for index, music in enumerate(self):
                 self.settings_db.set("playlist_item", str(index), json.dumps({'id': music.id, 'user': music.user}))
 
-    def load(self):
+    def load(self) -> None:
         current_index = self.settings_db.getint("playlist", "current_index", fallback=-1)
         if current_index == -1:
             return
@@ -218,7 +222,7 @@ class BasePlaylist(list):
                     music_wrappers.append(music_wrapper)
             self.from_list(music_wrappers, current_index)
 
-    def _debug_print(self):
+    def _debug_print(self) -> None:
         print("===== Playlist(%d) =====" % self.current_index)
         for index, item_wrapper in enumerate(self):
             if index == self.current_index:
@@ -227,14 +231,14 @@ class BasePlaylist(list):
                 print("%d %s" % (index, item_wrapper.format_debug_string()))
         print("=====     End     =====")
 
-    def async_validate(self):
+    def async_validate(self) -> None:
         if not self.validating_thread_lock.locked():
             time.sleep(0.1)  # Just avoid validation finishes too fast and delete songs while something is reading it.
             th = threading.Thread(target=self._check_valid, name="Validating")
             th.daemon = True
             th.start()
 
-    def _check_valid(self):
+    def _check_valid(self) -> None:
         self.log.debug("playlist: start validating...")
         self.validating_thread_lock.acquire()
         while len(self.pending_items) > 0:
@@ -268,12 +272,12 @@ class BasePlaylist(list):
 
 
 class OneshotPlaylist(BasePlaylist):
-    def __init__(self, cache, settings_db, music_db, config, send_channel_msg=None):
+    def __init__(self, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback | None = None) -> None:
         super().__init__(cache, settings_db, music_db, config, send_channel_msg)
         self.mode = "one-shot"
         self.current_index = -1
 
-    def current_item(self):
+    def current_item(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) == 0:
                 self.current_index = -1
@@ -284,7 +288,7 @@ class OneshotPlaylist(BasePlaylist):
 
             return self[self.current_index]
 
-    def from_list(self, _list, current_index):
+    def from_list(self, _list: list[CachedItemWrapper], current_index: int) -> Self:
         with self.playlist_lock:
             if len(_list) > 0:
                 if current_index > -1:
@@ -294,7 +298,7 @@ class OneshotPlaylist(BasePlaylist):
                 return super().from_list(_list, -1)
             return self
 
-    def next(self):
+    def next(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) > 0:
                 self.version += 1
@@ -311,19 +315,19 @@ class OneshotPlaylist(BasePlaylist):
                 self.current_index = -1
                 return False
 
-    def next_index(self):
+    def next_index(self) -> int | bool:
         if len(self) > 1:
             return 1
         else:
             return False
 
-    def next_item(self):
+    def next_item(self) -> CachedItemWrapper | bool:
         if len(self) > 1:
             return self[1]
         else:
             return False
 
-    def point_to(self, index):
+    def point_to(self, index: int) -> None:
         with self.playlist_lock:
             self.version += 1
             self.current_index = -1
@@ -332,11 +336,11 @@ class OneshotPlaylist(BasePlaylist):
 
 
 class RepeatPlaylist(BasePlaylist):
-    def __init__(self, cache, settings_db, music_db, config, send_channel_msg=None):
+    def __init__(self, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback | None = None) -> None:
         super().__init__(cache, settings_db, music_db, config, send_channel_msg)
         self.mode = "repeat"
 
-    def next(self):
+    def next(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) == 0:
                 return False
@@ -348,30 +352,30 @@ class RepeatPlaylist(BasePlaylist):
                 self.current_index = 0
                 return self[0]
 
-    def next_index(self):
+    def next_index(self) -> int:
         with self.playlist_lock:
             if self.current_index < len(self) - 1:
                 return self.current_index + 1
             else:
                 return 0
 
-    def next_item(self):
+    def next_item(self) -> CachedItemWrapper | bool:
         if len(self) == 0:
             return False
         return self[self.next_index()]
 
 
 class RandomPlaylist(BasePlaylist):
-    def __init__(self, cache, settings_db, music_db, config, send_channel_msg=None):
+    def __init__(self, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback | None = None) -> None:
         super().__init__(cache, settings_db, music_db, config, send_channel_msg)
         self.mode = "random"
 
-    def from_list(self, _list, current_index):
+    def from_list(self, _list: list[CachedItemWrapper], current_index: int) -> Self:
         self.version += 1
         random.shuffle(_list)
         return super().from_list(_list, -1)
 
-    def next(self):
+    def next(self) -> CachedItemWrapper | bool:
         with self.playlist_lock:
             if len(self) == 0:
                 return False
@@ -387,11 +391,11 @@ class RandomPlaylist(BasePlaylist):
 
 
 class AutoPlaylist(OneshotPlaylist):
-    def __init__(self, cache, settings_db, music_db, config, send_channel_msg=None):
+    def __init__(self, cache: MusicCache, settings_db: SettingsDatabase, music_db: MusicDatabase, config: ConfigParser, send_channel_msg: SendMsgCallback | None = None) -> None:
         super().__init__(cache, settings_db, music_db, config, send_channel_msg)
         self.mode = "autoplay"
 
-    def refresh(self):
+    def refresh(self) -> None:
         dicts = self.music_db.query_random_music(self.config.getint("bot", "autoplay_length"),
                                                  Condition().and_not_sub_condition(
                                                      Condition().and_like('tags', "%don't autoplay,%")))
@@ -400,11 +404,11 @@ class AutoPlaylist(OneshotPlaylist):
             _list = [self.cache.get_cached_wrapper_from_dict(_dict, "AutoPlay") for _dict in dicts]
             self.from_list(_list, -1)
 
-    def clear(self):
+    def clear(self) -> None:
         super().clear()
         self.refresh()
 
-    def next(self):
+    def next(self) -> CachedItemWrapper | bool:
         if len(self) == 0:
             self.refresh()
         return super().next()

--- a/src/media/radio.py
+++ b/src/media/radio.py
@@ -4,6 +4,7 @@ import struct
 import requests
 import traceback
 import hashlib
+from typing import Any
 
 from media.item import BaseItem
 from constants import tr_cli as tr
@@ -11,7 +12,7 @@ from constants import tr_cli as tr
 log = logging.getLogger("bot")
 
 
-def get_radio_server_description(url):
+def get_radio_server_description(url: str) -> str:
     global log
 
     log.debug("radio: fetching radio server description")
@@ -62,7 +63,7 @@ def get_radio_server_description(url):
     return url
 
 
-def get_radio_title(url):
+def get_radio_title(url: str) -> str:
     global log
 
     log.debug("radio: fetching radio server description")
@@ -98,7 +99,7 @@ class RadioItem(BaseItem):
         self.type = "radio"
 
     @classmethod
-    def from_dict(cls, d: dict) -> 'RadioItem':
+    def from_dict(cls, d: dict[str, Any]) -> 'RadioItem':
         instance = cls.__new__(cls)
         BaseItem.__init__(instance)
         instance._load_base_from_dict(d)
@@ -111,30 +112,30 @@ class RadioItem(BaseItem):
     def generate_id(url: str) -> str:
         return hashlib.md5(url.encode()).hexdigest()
 
-    def validate(self):
+    def validate(self) -> bool:
         self.version += 1  # 0 -> 1, notify the wrapper to save me when validate() is visited the first time
         return True
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         return True
 
-    def uri(self):
+    def uri(self) -> str:
         return self.url
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         dict = super().to_dict()
         dict['url'] = self.url
         dict['title'] = self.title
 
         return dict
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return "[radio] {name} ({url})".format(
             name=self.title,
             url=self.url
         )
 
-    def format_song_string(self, user):
+    def format_song_string(self, user: str) -> str:
         return tr("radio_item",
                   url=self.url,
                   title=get_radio_title(self.url),  # the title of current song
@@ -142,11 +143,11 @@ class RadioItem(BaseItem):
                   user=user
                   )
 
-    def format_current_playing(self, user):
+    def format_current_playing(self, user: str) -> str:
         return tr("now_playing", item=self.format_song_string(user))
 
-    def format_title(self):
+    def format_title(self) -> str:
         return self.title if self.title else self.url
 
-    def display_type(self):
+    def display_type(self) -> str:
         return tr("radio")

--- a/src/media/url.py
+++ b/src/media/url.py
@@ -5,13 +5,16 @@ import logging
 import os
 import threading
 import traceback
+from configparser import ConfigParser
 from io import BytesIO
+from typing import Any
 
 import yt_dlp as youtube_dl
 from PIL import Image
 
 import util
 from constants import tr_cli as tr
+from database import SettingsDatabase
 from media.item import BaseItem, ValidationFailedError, PreparationFailedError
 from util import format_time
 
@@ -19,7 +22,7 @@ log = logging.getLogger("bot")
 
 
 class URLItem(BaseItem):
-    def __init__(self, url: str, temp_folder: str, config, settings_db):
+    def __init__(self, url: str, temp_folder: str, config: ConfigParser, settings_db: SettingsDatabase):
         super().__init__()
         self.validating_lock = threading.Lock()
         self.temp_folder = temp_folder
@@ -36,7 +39,7 @@ class URLItem(BaseItem):
         self.type = "url"
 
     @classmethod
-    def from_dict(cls, d: dict, tmp_folder: str, config, settings_db) -> 'URLItem':
+    def from_dict(cls, d: dict[str, Any], tmp_folder: str, config: ConfigParser, settings_db: SettingsDatabase) -> 'URLItem':
         instance = cls.__new__(cls)
         BaseItem.__init__(instance)
         instance._load_base_from_dict(d)
@@ -54,10 +57,10 @@ class URLItem(BaseItem):
     def generate_id(url: str) -> str:
         return hashlib.md5(url.encode()).hexdigest()
 
-    def uri(self):
+    def uri(self) -> str:
         return self.path
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         if self.downloading or self.ready != 'yes':
             return False
         if self.ready == 'yes' and not os.path.exists(self.path):
@@ -68,7 +71,7 @@ class URLItem(BaseItem):
 
         return True
 
-    def validate(self):
+    def validate(self) -> bool:
         try:
             self.validating_lock.acquire()
             if self.ready in ['yes', 'validated']:
@@ -106,7 +109,7 @@ class URLItem(BaseItem):
             self.validating_lock.release()
 
     # Run in a other thread
-    def prepare(self):
+    def prepare(self) -> bool:
         if not self.downloading:
             assert self.ready == 'validated'
             return self._download()
@@ -114,7 +117,7 @@ class URLItem(BaseItem):
             assert self.ready == 'yes'
             return True
 
-    def _get_info_from_url(self):
+    def _get_info_from_url(self) -> bool | None:
         self.log.info("url: fetching metadata of url %s " % self.url)
         ydl_opts = {
             'noplaylist': True
@@ -149,7 +152,7 @@ class URLItem(BaseItem):
             self.log.error("url: error while fetching info from the URL")
             raise ValidationFailedError(tr('unable_download', item=self.format_title()))
 
-    def _download(self):
+    def _download(self) -> bool:
         util.clear_tmp_folder(self.temp_folder, self.config.getint('bot', 'tmp_folder_max_size'))
 
         self.downloading = True
@@ -212,19 +215,19 @@ class URLItem(BaseItem):
                 self.downloading = False
                 raise PreparationFailedError(tr('unable_download', item=self.format_title()))
 
-    def _read_thumbnail_from_file(self, path_thumbnail):
+    def _read_thumbnail_from_file(self, path_thumbnail: str) -> None:
         if os.path.isfile(path_thumbnail):
             im = Image.open(path_thumbnail)
             self.thumbnail = self._prepare_thumbnail(im)
 
-    def _prepare_thumbnail(self, im):
+    def _prepare_thumbnail(self, im: Image.Image) -> str:
         im.thumbnail((100, 100), Image.LANCZOS)
         buffer = BytesIO()
         im = im.convert('RGB')
         im.save(buffer, format="JPEG")
         return base64.b64encode(buffer.getvalue()).decode('utf-8')
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         dict = super().to_dict()
         dict['type'] = 'url'
         dict['url'] = self.url
@@ -235,13 +238,13 @@ class URLItem(BaseItem):
 
         return dict
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return "[url] {title} ({url})".format(
             title=self.title,
             url=self.url
         )
 
-    def format_song_string(self, user):
+    def format_song_string(self, user: str) -> str:
         if self.ready in ['validated', 'yes']:
             return tr("url_item",
                       title=self.title if self.title else "??",
@@ -249,7 +252,7 @@ class URLItem(BaseItem):
                       user=user)
         return self.url
 
-    def format_current_playing(self, user):
+    def format_current_playing(self, user: str) -> str:
         display = tr("now_playing", item=self.format_song_string(user))
 
         if self.thumbnail:
@@ -259,8 +262,8 @@ class URLItem(BaseItem):
 
         return display
 
-    def format_title(self):
+    def format_title(self) -> str:
         return self.title if self.title else self.url
 
-    def display_type(self):
+    def display_type(self) -> str:
         return tr("url")

--- a/src/media/url_from_playlist.py
+++ b/src/media/url_from_playlist.py
@@ -1,17 +1,20 @@
 import hashlib
 import logging
 import threading
+from configparser import ConfigParser
+from typing import Any
 
 import yt_dlp as youtube_dl
 
 from constants import tr_cli as tr
+from database import SettingsDatabase
 from media.item import BaseItem
 from media.url import URLItem
 
 log = logging.getLogger("bot")
 
 
-def get_playlist_info(url, config, start_index=0, user=""):
+def get_playlist_info(url: str, config: ConfigParser, start_index: int = 0, user: str = "") -> list[dict[str, Any]] | None:
     ydl_opts = {
         'extract_flat': 'in_playlist',
         'verbose': config.getboolean('debug', 'youtube_dl')
@@ -61,7 +64,7 @@ def get_playlist_info(url, config, start_index=0, user=""):
 
 
 class PlaylistURLItem(URLItem):
-    def __init__(self, url: str, title: str, playlist_url: str, playlist_title: str, temp_folder: str, config, settings_db):
+    def __init__(self, url: str, title: str, playlist_url: str, playlist_title: str, temp_folder: str, config: ConfigParser, settings_db: SettingsDatabase):
         super().__init__(url, temp_folder, config, settings_db)
         self.title = title
         self.playlist_url = playlist_url
@@ -69,7 +72,7 @@ class PlaylistURLItem(URLItem):
         self.type = "url_from_playlist"
 
     @classmethod
-    def from_dict(cls, d: dict, tmp_folder: str, config, settings_db) -> 'PlaylistURLItem':
+    def from_dict(cls, d: dict[str, Any], tmp_folder: str, config: ConfigParser, settings_db: SettingsDatabase) -> 'PlaylistURLItem':
         instance = cls.__new__(cls)
         BaseItem.__init__(instance)
         instance._load_base_from_dict(d)
@@ -91,21 +94,21 @@ class PlaylistURLItem(URLItem):
     def generate_id(url: str) -> str:
         return hashlib.md5(url.encode()).hexdigest()
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         tmp_dict = super().to_dict()
         tmp_dict['playlist_url'] = self.playlist_url
         tmp_dict['playlist_title'] = self.playlist_title
 
         return tmp_dict
 
-    def format_debug_string(self):
+    def format_debug_string(self) -> str:
         return "[url] {title} ({url}) from playlist {playlist}".format(
             title=self.title,
             url=self.url,
             playlist=self.playlist_title
         )
 
-    def format_song_string(self, user):
+    def format_song_string(self, user: str) -> str:
         return tr("url_from_playlist_item",
                   title=self.title,
                   url=self.url,
@@ -113,7 +116,7 @@ class PlaylistURLItem(URLItem):
                   playlist=self.playlist_title,
                   user=user)
 
-    def format_current_playing(self, user):
+    def format_current_playing(self, user: str) -> str:
         display = tr("now_playing", item=self.format_song_string(user))
 
         if self.thumbnail:
@@ -123,5 +126,5 @@ class PlaylistURLItem(URLItem):
 
         return display
 
-    def display_type(self):
+    def display_type(self) -> str:
         return tr("url_from_playlist")

--- a/src/mumbleBot.py
+++ b/src/mumbleBot.py
@@ -13,12 +13,19 @@ import sys
 import threading
 import time
 import traceback
+import types
+from argparse import Namespace
+from configparser import ConfigParser
+from typing import Callable, Any
 
 import audioop
 
 import util
 from constants import tr_cli as tr
+from database import SettingsDatabase, MusicDatabase
+from media.cache import MusicCache, CachedItemWrapper
 from media.item import ValidationFailedError, PreparationFailedError
+from media.playlist import BasePlaylist
 from pymumble_py3.mumble import Mumble
 from pymumble_py3.pymumble_constants import PYMUMBLE_CONN_STATE_FAILED, PYMUMBLE_CLBK_TEXTMESSAGERECEIVED, \
     PYMUMBLE_CLBK_SOUNDRECEIVED, PYMUMBLE_CLBK_USERREMOVED, PYMUMBLE_CLBK_USERUPDATED
@@ -27,8 +34,9 @@ from pymumble_py3.pymumble_constants import PYMUMBLE_CONN_STATE_FAILED, PYMUMBLE
 class MumbleBot:
     version = 'git'
 
-    def __init__(self, args, config, settings_db, music_db, cache, playlist, music_folder,
-                 settings_db_path, music_db_path):
+    def __init__(self, args: Namespace, config: ConfigParser, settings_db: SettingsDatabase,
+                 music_db: MusicDatabase, cache: MusicCache, playlist: BasePlaylist,
+                 music_folder: str, settings_db_path: str, music_db_path: str) -> None:
         self.log = logging.getLogger("bot")
         self.log.info(f"bot: botamusique version {self.get_version()}, starting...")
         signal.signal(signal.SIGINT, self.ctrl_caught)
@@ -187,7 +195,7 @@ class MumbleBot:
         self.redirect_ffmpeg_log = self.config.getboolean('debug', 'redirect_ffmpeg_log')
 
     # Set the CTRL+C shortcut
-    def ctrl_caught(self, signal, frame):
+    def ctrl_caught(self, signal: int, frame: types.FrameType | None) -> None:
         self.log.info(
             "\nSIGINT caught, quitting, {} more to kill".format(2 - self.nb_exit))
 
@@ -198,13 +206,13 @@ class MumbleBot:
 
         self.exit = True
 
-    def get_version(self):
+    def get_version(self) -> str:
         if self.version != "git":
             return self.version
         else:
             return util.get_snapshot_version()
 
-    def register_command(self, cmd, handle, no_partial_match=False, access_outside_channel=False, admin=False):
+    def register_command(self, cmd: str, handle: Callable[..., None], no_partial_match: bool = False, access_outside_channel: bool = False, admin: bool = False) -> None:
         cmds = cmd.split(",")
         for command in cmds:
             command = command.strip()
@@ -215,10 +223,10 @@ class MumbleBot:
                                             'admin': admin}
                 self.log.debug("bot: command added: " + command)
 
-    def set_comment(self):
+    def set_comment(self) -> None:
         self.mumble.users.myself.comment(self.config.get('bot', 'comment'))
 
-    def set_avatar(self):
+    def set_avatar(self) -> None:
         avatar_path = self.config.get('bot', 'avatar')
 
         if avatar_path:
@@ -227,7 +235,7 @@ class MumbleBot:
         else:
             self.mumble.users.myself.texture(b'')
 
-    def join_channel(self):
+    def join_channel(self) -> None:
         if self.channel:
             if '/' in self.channel:
                 self.mumble.channels.find_by_tree(self.channel.split('/')).move_in()
@@ -239,7 +247,7 @@ class MumbleBot:
     # =======================
 
     # All text send to the chat is analysed by this function
-    def message_received(self, text):
+    def message_received(self, text: Any) -> None:
         raw_message = text.message.strip()
         message = re.sub(r'<.*?>', '', raw_message)
         if text.actor == 0:
@@ -326,17 +334,17 @@ class MumbleBot:
                 self.log.error(f"bot: command {command_exc} failed with error: {error_traceback}\n")
                 self.send_msg(tr('error_executing_command', command=command_exc, error=error), text)
 
-    def send_msg(self, msg, text):
+    def send_msg(self, msg: str, text: Any) -> None:
         msg = msg.encode('utf-8', 'ignore').decode('utf-8')
         # text if the object message, contain information if direct message or channel message
         self.mumble.users[text.actor].send_text_message(msg)
 
-    def send_channel_msg(self, msg):
+    def send_channel_msg(self, msg: str) -> None:
         msg = msg.encode('utf-8', 'ignore').decode('utf-8')
         own_channel = self.mumble.channels[self.mumble.users.myself['channel_id']]
         own_channel.send_text_message(msg)
 
-    def is_admin(self, user):
+    def is_admin(self, user: str) -> bool:
         list_admin = self.config.get('bot', 'admin').rstrip().split(';')
         if user in list_admin:
             return True
@@ -347,7 +355,7 @@ class MumbleBot:
     #   Other Mumble Events
     # =======================
 
-    def get_user_count_in_channel(self):
+    def get_user_count_in_channel(self) -> int:
         # Get the channel, based on the channel id
         own_channel = self.mumble.channels[self.mumble.users.myself['channel_id']]
 
@@ -360,7 +368,7 @@ class MumbleBot:
         # Return the number of elements in the set, as the final user count
         return len(users)
 
-    def users_changed(self, user, message):
+    def users_changed(self, user: Any, message: Any) -> None:
         # only check if there is one more user currently in the channel
         # else when the music is paused and somebody joins, music would start playing again
         user_count = self.get_user_count_in_channel()
@@ -385,7 +393,7 @@ class MumbleBot:
     #   Launch and Download
     # =======================
 
-    def launch_music(self, music_wrapper, start_from=0):
+    def launch_music(self, music_wrapper: CachedItemWrapper, start_from: float = 0) -> None:
         assert music_wrapper.is_ready()
 
         uri = music_wrapper.uri()
@@ -417,7 +425,7 @@ class MumbleBot:
 
         self.thread = sp.Popen(command, stdout=sp.PIPE, stderr=pipe_wd, bufsize=self.pcm_buffer_size)
 
-    def async_download_next(self):
+    def async_download_next(self) -> None:
         # Function start if the next music isn't ready
         # Do nothing in case the next music is already downloaded
         self.log.debug("bot: Async download next asked ")
@@ -436,7 +444,7 @@ class MumbleBot:
                 self.playlist.remove_by_id(next.id)
                 self.cache.free_and_delete(next.id)
 
-    def async_download(self, item):
+    def async_download(self, item: CachedItemWrapper) -> threading.Thread:
         th = threading.Thread(
             target=self._download, name="Prepare-" + item.id[:7], args=(item,))
         self.log.info(f"bot: start preparing item in thread: {item.format_debug_string()}")
@@ -444,14 +452,14 @@ class MumbleBot:
         th.start()
         return th
 
-    def start_download(self, item):
+    def start_download(self, item: CachedItemWrapper) -> None:
         if not item.is_ready():
             self.log.info("bot: current music isn't ready, start downloading.")
             self.async_download(item)
             self.send_channel_msg(
                 tr('download_in_progress', item=item.format_title()))
 
-    def _download(self, item):
+    def _download(self, item: CachedItemWrapper) -> bool:
         ver = item.version
         try:
             item.validate()
@@ -477,7 +485,7 @@ class MumbleBot:
     # =======================
 
     # Main loop of the Bot
-    def loop(self):
+    def loop(self) -> None:
         while not self.exit and self.mumble.is_alive():
 
             while self.thread and self.mumble.sound_output.get_buffer_size() > 0.5 and not self.exit:
@@ -593,7 +601,7 @@ class MumbleBot:
                 self.log.info("bot: save playlist into database")
                 self.playlist.save()
 
-    def volume_cycle(self):
+    def volume_cycle(self) -> None:
         delta = time.time() - self.last_volume_cycle_time
 
         if self.on_ducking and self.ducking_release < time.time():
@@ -611,7 +619,7 @@ class MumbleBot:
 
             self.last_volume_cycle_time = time.time()
 
-    def ducking_sound_received(self, user, sound):
+    def ducking_sound_received(self, user: Any, sound: Any) -> None:
         rms = audioop.rms(sound.pcm, 2)
         self._max_rms = max(rms, self._max_rms)
         if self._display_rms:
@@ -627,7 +635,7 @@ class MumbleBot:
                 self.on_ducking = True
             self.ducking_release = time.time() + 1  # ducking release after 1s
 
-    def _fadeout(self, _pcm_data, stereo=False, fadein=False):
+    def _fadeout(self, _pcm_data: bytes, stereo: bool = False, fadein: bool = False) -> bytes:
         pcm_data = bytearray(_pcm_data)
         if stereo:
             if not fadein:
@@ -656,7 +664,7 @@ class MumbleBot:
     #      Play Control
     # =======================
 
-    def play(self, index=-1, start_at=0):
+    def play(self, index: int = -1, start_at: float = 0) -> None:
         if not self.is_pause:
             self.interrupt()
 
@@ -671,14 +679,14 @@ class MumbleBot:
         self.song_start_at = -1
         self.playhead = start_at
 
-    def clear(self):
+    def clear(self) -> None:
         # Kill the ffmpeg thread and empty the playlist
         self.interrupt()
         self.playlist.clear()
         self.wait_for_ready = False
         self.log.info("bot: music stopped. playlist trashed.")
 
-    def stop(self):
+    def stop(self) -> None:
         self.interrupt()
         self.is_pause = True
         if len(self.playlist) > 0:
@@ -687,7 +695,7 @@ class MumbleBot:
             self.wait_for_ready = False
         self.log.info("bot: music stopped.")
 
-    def interrupt(self):
+    def interrupt(self) -> None:
         # Kill the ffmpeg thread
         if self.thread:
             self.on_interrupting = True
@@ -696,7 +704,7 @@ class MumbleBot:
             self.song_start_at = -1
             self.read_pcm_size = 0
 
-    def pause(self):
+    def pause(self) -> None:
         # Kill the ffmpeg thread
         self.interrupt()
         self.is_pause = True
@@ -705,7 +713,7 @@ class MumbleBot:
             self.pause_at_id = self.playlist.current_item().id
             self.log.info(f"bot: music paused at {self.playhead:.2f} seconds.")
 
-    def resume(self):
+    def resume(self) -> None:
         self.is_pause = False
         if self.playlist.current_index == -1:
             self.playlist.next()
@@ -722,7 +730,7 @@ class MumbleBot:
         self.pause_at_id = ""
 
 
-def start_web_interface(addr, port, bot):
+def start_web_interface(addr: str, port: int, bot: MumbleBot) -> None:
     global formatter
     import interface
 

--- a/src/util.py
+++ b/src/util.py
@@ -19,6 +19,8 @@ from typing import Any
 import requests
 import yt_dlp as youtube_dl
 
+from database import SettingsDatabase
+
 YT_PKG_NAME = 'yt-dlp'
 
 log = logging.getLogger("bot")
@@ -44,7 +46,7 @@ def solve_filepath(path: str) -> str:
 #       - prefix can be controlled by the caller
 #       - hash is a sha1 of the string representation of the directories' contents (which are
 #           zipped)
-def zipdir(files, temp_folder, config, zipname_prefix=None):
+def zipdir(files: list[str], temp_folder: str, config: ConfigParser, zipname_prefix: str | None = None) -> str:
     zipname = temp_folder
     if zipname_prefix and '../' not in zipname_prefix:
         zipname += zipname_prefix.strip().replace('/', '_') + '_'
@@ -70,14 +72,14 @@ def zipdir(files, temp_folder, config, zipname_prefix=None):
     return zipname
 
 
-def get_user_ban(settings_db):
+def get_user_ban(settings_db: SettingsDatabase) -> str:
     res = "List of ban hash"
     for i in settings_db.items("user_ban"):
         res += "<br/>" + i[0]
     return res
 
 
-def update(current_version, config):
+def update(current_version: str, config: ConfigParser) -> str:
     global log
 
     msg = ""
@@ -94,7 +96,7 @@ def update(current_version, config):
     return msg
 
 
-def pipe_no_wait():
+def pipe_no_wait() -> tuple[int, int] | tuple[None, None]:
     """ Generate a non-block pipe used to fetch the STDERR of ffmpeg.
     """
 
@@ -146,13 +148,13 @@ def pipe_no_wait():
 
 
 class Dir(object):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.name = os.path.basename(path.strip('/'))
         self.fullpath = path
-        self.subdirs = {}
-        self.files = []
+        self.subdirs: dict[str, 'Dir'] = {}
+        self.files: list[str] = []
 
-    def add_file(self, file):
+    def add_file(self, file: str) -> bool:
         if file.startswith(self.name + '/'):
             file = file.replace(self.name + '/', '', 1)
 
@@ -168,8 +170,8 @@ class Dir(object):
             self.files.append(file)
         return True
 
-    def get_subdirs(self, path=None):
-        subdirs = []
+    def get_subdirs(self, path: str | None = None) -> list[str] | dict[str, 'Dir']:
+        subdirs: list[str] | dict[str, 'Dir'] = []
         if path and path != '' and path != './':
             subdir = path.split('/')[0]
             if subdir in self.subdirs:
@@ -181,8 +183,8 @@ class Dir(object):
 
         return subdirs
 
-    def get_subdirs_recursively(self, path=None):
-        subdirs = []
+    def get_subdirs_recursively(self, path: str | None = None) -> list[str]:
+        subdirs: list[str] = []
         if path and path != '' and path != './':
             subdir = path.split('/')[0]
             if subdir in self.subdirs:
@@ -197,8 +199,8 @@ class Dir(object):
         subdirs.sort()
         return subdirs
 
-    def get_files(self, path=None):
-        files = []
+    def get_files(self, path: str | None = None) -> list[str]:
+        files: list[str] = []
         if path and path != '' and path != './':
             subdir = path.split('/')[0]
             if subdir in self.subdirs:
@@ -209,8 +211,8 @@ class Dir(object):
 
         return files
 
-    def get_files_recursively(self, path=None):
-        files = []
+    def get_files_recursively(self, path: str | None = None) -> list[str]:
+        files: list[str] = []
         if path and path != '' and path != './':
             subdir = path.split('/')[0]
             if subdir in self.subdirs:
@@ -224,7 +226,7 @@ class Dir(object):
 
         return files
 
-    def render_text(self, ident=0):
+    def render_text(self, ident: int = 0) -> None:
         print('{}{}/'.format(' ' * (ident * 4), self.name))
         for key, val in self.subdirs.items():
             val.render_text(ident + 1)
@@ -234,7 +236,7 @@ class Dir(object):
 
 # Parse the html from the message to get the URL
 
-def get_url_from_input(string):
+def get_url_from_input(string: str) -> str:
     string = string.strip()
     if not (string.startswith("http") or string.startswith("HTTP")):
         res = re.search('href="(.+?)"', string, flags=re.IGNORECASE)
@@ -252,7 +254,7 @@ def get_url_from_input(string):
         return ""
 
 
-def youtube_search(query, config):
+def youtube_search(query: str, config: ConfigParser) -> list[list[str]] | bool:
     global log
     import json
 
@@ -292,7 +294,7 @@ def youtube_search(query, config):
         return False
 
 
-def get_media_duration(path):
+def get_media_duration(path: str) -> float:
     command = ("ffprobe", "-v", "quiet", "-show_entries", "format=duration",
                "-of", "default=noprint_wrappers=1:nokey=1", path)
     process = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
@@ -307,7 +309,7 @@ def get_media_duration(path):
         return 0
 
 
-def parse_time(human):
+def parse_time(human: str) -> float:
     match = re.search("(?:(\\d\\d):)?(?:(\\d\\d):)?(\\d+(?:\\.\\d*)?)", human, flags=re.IGNORECASE)
     if match:
         if match[1] is None and match[2] is None:
@@ -320,7 +322,7 @@ def parse_time(human):
         raise ValueError("Invalid time string given.")
 
 
-def format_time(seconds):
+def format_time(seconds: float) -> str:
     hours = seconds // 3600
     seconds = seconds % 3600
     minutes = seconds // 60
@@ -328,7 +330,7 @@ def format_time(seconds):
     return f"{hours:d}:{minutes:02d}:{seconds:02d}"
 
 
-def parse_file_size(human):
+def parse_file_size(human: str) -> int:
     units = {"B": 1, "KB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024, "TB": 1024 * 1024 * 1024 * 1024,
              "K": 1024, "M": 1024 * 1024, "G": 1024 * 1024 * 1024, "T": 1024 * 1024 * 1024 * 1024}
     match = re.search("(\\d+(?:\\.\\d*)?)\\s*([A-Za-z]+)", human, flags=re.IGNORECASE)
@@ -341,14 +343,14 @@ def parse_file_size(human):
     raise ValueError("Invalid file size given.")
 
 
-def get_salted_password_hash(password):
+def get_salted_password_hash(password: str) -> tuple[str, str]:
     salt = os.urandom(10)
     hashed = hashlib.pbkdf2_hmac('sha1', password.encode("utf-8"), salt, 100000)
 
     return hashed.hex(), salt.hex()
 
 
-def verify_password(password, salted_hash, salt):
+def verify_password(password: str, salted_hash: str, salt: str) -> bool:
     hashed = hashlib.pbkdf2_hmac('sha1', password.encode("utf-8"), bytearray.fromhex(salt), 100000)
     if hashed.hex() == salted_hash:
         return True
@@ -380,7 +382,7 @@ def set_logging_formatter(handler: logging.Handler, logging_level: int) -> None:
     handler.setFormatter(formatter)
 
 
-def get_snapshot_version():
+def get_snapshot_version() -> str:
     import subprocess
     wd = os.getcwd()
     root_dir = os.path.dirname(__file__)
@@ -403,42 +405,42 @@ def get_snapshot_version():
 
 
 class LoggerIOWrapper(io.TextIOWrapper):
-    def __init__(self, logger: logging.Logger, logging_level, fallback_io_buffer):
+    def __init__(self, logger: logging.Logger, logging_level: int, fallback_io_buffer: io.RawIOBase) -> None:
         super().__init__(fallback_io_buffer, write_through=True)
         self.logger = logger
         self.logging_level = logging_level
 
-    def write(self, text):
+    def write(self, text: str | bytes) -> int:
         if isinstance(text, bytes):
             msg = text.decode('utf-8').rstrip()
             self.logger.log(self.logging_level, msg)
-            super().write(msg + "\n")
+            return super().write(msg + "\n")
         else:
             self.logger.log(self.logging_level, text.rstrip())
-            super().write(text + "\n")
+            return super().write(text + "\n")
 
 
 class VolumeHelper:
-    def __init__(self, plain_volume=0, ducking_plain_volume=0):
-        self.plain_volume_set = 0
-        self.plain_ducking_volume_set = 0
-        self.volume_set = 0
-        self.ducking_volume_set = 0
+    def __init__(self, plain_volume: float = 0, ducking_plain_volume: float = 0) -> None:
+        self.plain_volume_set: float = 0
+        self.plain_ducking_volume_set: float = 0
+        self.volume_set: float = 0
+        self.ducking_volume_set: float = 0
 
-        self.real_volume = 0
+        self.real_volume: float = 0
 
         self.set_volume(plain_volume)
         self.set_ducking_volume(ducking_plain_volume)
 
-    def set_volume(self, plain_volume):
+    def set_volume(self, plain_volume: float) -> None:
         self.volume_set = self._convert_volume(plain_volume)
         self.plain_volume_set = plain_volume
 
-    def set_ducking_volume(self, plain_volume):
+    def set_ducking_volume(self, plain_volume: float) -> None:
         self.ducking_volume_set = self._convert_volume(plain_volume)
         self.plain_ducking_volume_set = plain_volume
 
-    def _convert_volume(self, volume):
+    def _convert_volume(self, volume: float) -> float:
         if volume == 0:
             return 0
 
@@ -449,7 +451,7 @@ class VolumeHelper:
         return (10 ** (dB / 20) - 10 ** (-35 / 20)) / (1 - 10 ** (-35 / 20))
 
 
-def get_size_folder(path):
+def get_size_folder(path: str) -> int:
     global log
 
     folder_size = 0
@@ -463,7 +465,7 @@ def get_size_folder(path):
     return int(folder_size / (1024 * 1024))
 
 
-def clear_tmp_folder(path, size):
+def clear_tmp_folder(path: str, size: int) -> None:
     global log
 
     if size == -1:
@@ -513,7 +515,7 @@ def check_extra_config(config: ConfigParser, template: ConfigParser) -> list[tup
     return extra
 
 
-def parse_cookie_file(cookiefile):
+def parse_cookie_file(cookiefile: str) -> dict[str, str]:
     # https://stackoverflow.com/a/54659484/1584825
 
     cookies = {}


### PR DESCRIPTION
Annotates all major modules with Python 3.10+ type hints (PEP 604 union syntax, built-in generics). Uses TYPE_CHECKING guards in command.py and interface.py to avoid circular imports with MumbleBot. Adds Self return types to the Condition fluent builder and a SendMsgCallback type alias in playlist.py.