### PR TITLE
Clean imports and other Python 3.14 improvements

### DIFF
--- a/src/botamusique/command.py
+++ b/src/botamusique/command.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-from __future__ import annotations
 
 import datetime
 import json

--- a/src/botamusique/command.py
+++ b/src/botamusique/command.py
@@ -5,7 +5,7 @@ import json
 import logging
 import re
 import secrets
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pyradios import RadioBrowser
 
@@ -18,9 +18,7 @@ from botamusique.constants import tr_cli as tr
 from botamusique.database import SettingsDatabase, MusicDatabase, Condition
 from botamusique.media.cache import CachedItemWrapper
 from botamusique.media.url_from_playlist import get_playlist_info
-
-if TYPE_CHECKING:
-    from mumbleBot import MumbleBot
+from botamusique.mumbleBot import MumbleBot
 
 log = logging.getLogger("bot")
 

--- a/src/botamusique/command.py
+++ b/src/botamusique/command.py
@@ -357,8 +357,7 @@ def cmd_play_file_match(bot: MumbleBot, user: str, text: Any, command: str, para
             music_wrappers = []
             for file_dict in file_dicts:
                 file = file_dict['title']
-                match = re.search(parameter, file)
-                if match and match[0]:
+                if (match := re.search(parameter, file)) and match[0]:
                     count += 1
                     music_wrapper = bot.cache.get_cached_wrapper(bot.cache.dict_to_item(file_dict), user)
                     music_wrappers.append(music_wrapper)
@@ -893,8 +892,7 @@ def cmd_repeat(bot: MumbleBot, user: str, text: Any, command: str, parameter: st
     if parameter and parameter.isdigit():
         repeat = int(parameter)
 
-    music = bot.playlist.current_item()
-    if music:
+    if music := bot.playlist.current_item():
         for _ in range(repeat):
             bot.playlist.insert(
                 bot.playlist.current_index + 1,

--- a/src/botamusique/interface.py
+++ b/src/botamusique/interface.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-from __future__ import annotations
 
 import errno
 import json

--- a/src/botamusique/interface.py
+++ b/src/botamusique/interface.py
@@ -10,7 +10,7 @@ import sqlite3
 import time
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 from flask import Flask, Blueprint, render_template, request, redirect, send_file, Response, jsonify, abort, session
 
@@ -22,12 +22,10 @@ from botamusique.media.item import BaseItem
 from botamusique.media.radio import RadioItem
 from botamusique.media.url import URLItem
 from botamusique.media.url_from_playlist import PlaylistURLItem
+from botamusique.mumbleBot import MumbleBot
 
-if TYPE_CHECKING:
-    from mumbleBot import MumbleBot
 
 _bot: MumbleBot | None = None
-
 
 def set_bot(bot: MumbleBot) -> None:
     global _bot

--- a/src/botamusique/main.py
+++ b/src/botamusique/main.py
@@ -279,10 +279,10 @@ def start_web_interface(addr: str, port: int, bot: MumbleBot) -> None:
         handler = logging.StreamHandler()
 
     # replace werkzeug_logger handlers with ours
-    for handler in list(werkzeug_logger.handlers):
-        if isinstance(handler, logging.StreamHandler):
-            werkzeug_logger.removeHandler(handler)
-            handler.close()
+    for existing in list(werkzeug_logger.handlers):
+        if isinstance(existing, logging.StreamHandler):
+            werkzeug_logger.removeHandler(existing)
+            existing.close()
     werkzeug_logger.addHandler(handler)
 
     interface.init_app()

--- a/src/botamusique/main.py
+++ b/src/botamusique/main.py
@@ -12,11 +12,12 @@ from typing import Any
 
 from botamusique import command
 from botamusique import constants
+from botamusique import interface
 from botamusique import util
 from botamusique.database import SettingsDatabase, MusicDatabase, DatabaseMigration
 from botamusique.media.cache import MusicCache
 from botamusique.media.playlist import get_playlist
-from botamusique.mumbleBot import MumbleBot, start_web_interface
+from botamusique.mumbleBot import MumbleBot
 
 
 def main() -> None:
@@ -266,6 +267,29 @@ def main() -> None:
 
     # Start the main loop.
     bot.loop()
+
+def start_web_interface(addr: str, port: int, bot: MumbleBot) -> None:
+    # setup logger
+    werkzeug_logger = logging.getLogger('werkzeug')
+    werkzeug_logger.propagate = False
+    logfile = util.solve_filepath(bot.config.get('webinterface', 'web_logfile'))
+    if logfile:
+        handler = logging.handlers.RotatingFileHandler(logfile, mode='a', maxBytes=10240, backupCount=3)  # Rotate after 10KB, leave 3 old logs
+    else:
+        handler = logging.StreamHandler()
+
+    # replace werkzeug_logger handlers with ours
+    for handler in list(werkzeug_logger.handlers):
+        if isinstance(handler, logging.StreamHandler):
+            werkzeug_logger.removeHandler(handler)
+            handler.close()
+    werkzeug_logger.addHandler(handler)
+
+    interface.init_app()
+    interface.set_bot(bot)
+    interface.init_proxy()
+    interface.web.secret_key = bot.config.get('webinterface', 'flask_secret')
+    interface.web.run(port=port, host=addr)
 
 if __name__ == '__main__':
     main()

--- a/src/botamusique/main.py
+++ b/src/botamusique/main.py
@@ -268,6 +268,7 @@ def main() -> None:
     # Start the main loop.
     bot.loop()
 
+
 def start_web_interface(addr: str, port: int, bot: MumbleBot) -> None:
     # setup logger
     werkzeug_logger = logging.getLogger('werkzeug')

--- a/src/botamusique/media/playlist.py
+++ b/src/botamusique/media/playlist.py
@@ -102,16 +102,16 @@ class BasePlaylist(list):
         self.async_validate()
         return items
 
-    def next(self) -> CachedItemWrapper | bool:
+    def next(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) == 0:
-                return False
+                return None
 
             if self.current_index < len(self) - 1:
                 self.current_index += 1
                 return self[self.current_index]
             else:
-                return False
+                return None
 
     def point_to(self, index: int) -> None:
         with self.playlist_lock:
@@ -125,14 +125,14 @@ class BasePlaylist(list):
                     return index
         return None
 
-    def __delitem__(self, key: int) -> CachedItemWrapper | bool:
+    def __delitem__(self, key: int) -> CachedItemWrapper | None:
         return self.remove(key)
 
-    def remove(self, index: int) -> CachedItemWrapper | bool:
+    def remove(self, index: int) -> CachedItemWrapper | None:
         with self.playlist_lock:
             self.version += 1
             if index > len(self) - 1:
-                return False
+                return None
 
             removed = self[index]
             super().__delitem__(index)
@@ -162,26 +162,26 @@ class BasePlaylist(list):
         for index in to_be_removed:
             self.remove(index)
 
-    def current_item(self) -> CachedItemWrapper | bool:
+    def current_item(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) == 0:
-                return False
+                return None
 
             return self[self.current_index]
 
-    def next_index(self) -> int | bool:
+    def next_index(self) -> int | None:
         with self.playlist_lock:
             if self.current_index < len(self) - 1:
                 return self.current_index + 1
 
-        return False
+        return None
 
-    def next_item(self) -> CachedItemWrapper | bool:
+    def next_item(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if self.current_index < len(self) - 1:
                 return self[self.current_index + 1]
+            return None
 
-        return False
 
     def randomize(self) -> None:
         with self.playlist_lock:
@@ -277,11 +277,11 @@ class OneshotPlaylist(BasePlaylist):
         self.mode = "one-shot"
         self.current_index = -1
 
-    def current_item(self) -> CachedItemWrapper | bool:
+    def current_item(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) == 0:
                 self.current_index = -1
-                return False
+                return None
 
             if self.current_index == -1:
                 self.current_index = 0
@@ -298,7 +298,7 @@ class OneshotPlaylist(BasePlaylist):
                 return super().from_list(_list, -1)
             return self
 
-    def next(self) -> CachedItemWrapper | bool:
+    def next(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) > 0:
                 self.version += 1
@@ -306,26 +306,26 @@ class OneshotPlaylist(BasePlaylist):
                 if self.current_index != -1:
                     super().__delitem__(self.current_index)
                     if len(self) == 0:
-                        return False
+                        return None
                 else:
                     self.current_index = 0
 
                 return self[0]
             else:
                 self.current_index = -1
-                return False
+                return None
 
-    def next_index(self) -> int | bool:
+    def next_index(self) -> int | None:
         if len(self) > 1:
             return 1
         else:
-            return False
+            return None
 
-    def next_item(self) -> CachedItemWrapper | bool:
+    def next_item(self) -> CachedItemWrapper | None:
         if len(self) > 1:
             return self[1]
         else:
-            return False
+            return None
 
     def point_to(self, index: int) -> None:
         with self.playlist_lock:
@@ -340,10 +340,10 @@ class RepeatPlaylist(BasePlaylist):
         super().__init__(cache, settings_db, music_db, config, send_channel_msg)
         self.mode = "repeat"
 
-    def next(self) -> CachedItemWrapper | bool:
+    def next(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) == 0:
-                return False
+                return None
 
             if self.current_index < len(self) - 1:
                 self.current_index += 1
@@ -359,9 +359,9 @@ class RepeatPlaylist(BasePlaylist):
             else:
                 return 0
 
-    def next_item(self) -> CachedItemWrapper | bool:
+    def next_item(self) -> CachedItemWrapper | None:
         if len(self) == 0:
-            return False
+            return None
         return self[self.next_index()]
 
 
@@ -375,10 +375,10 @@ class RandomPlaylist(BasePlaylist):
         random.shuffle(_list)
         return super().from_list(_list, -1)
 
-    def next(self) -> CachedItemWrapper | bool:
+    def next(self) -> CachedItemWrapper | None:
         with self.playlist_lock:
             if len(self) == 0:
-                return False
+                return None
 
             if self.current_index < len(self) - 1:
                 self.current_index += 1

--- a/src/botamusique/mumbleBot.py
+++ b/src/botamusique/mumbleBot.py
@@ -335,8 +335,7 @@ class MumbleBot:
             user = user.split()[0]
 
         command_symbols = self.config.get('commands', 'command_symbol')
-        match = re.match(fr'^[{re.escape(command_symbols)}](?P<command>\S+)(?:\s(?P<argument>.*))?', message)
-        if match:
+        if match := re.match(fr'^[{re.escape(command_symbols)}](?P<command>\S+)(?:\s(?P<argument>.*))?', message):
             command = match.group("command").lower()
             argument = match.group("argument") or ""
 

--- a/src/botamusique/mumbleBot.py
+++ b/src/botamusique/mumbleBot.py
@@ -502,20 +502,19 @@ class MumbleBot:
         # Function start if the next music isn't ready
         # Do nothing in case the next music is already downloaded
         self.log.debug("bot: Async download next asked ")
-        while self.playlist.next_item():
+        while next_item := self.playlist.next_item():
             # usually, all validation will be done when adding to the list.
             # however, for performance consideration, youtube playlist won't be validate when added.
             # the validation has to be done here.
-            next = self.playlist.next_item()
             try:
-                if not next.is_ready():
-                    self.async_download(next)
+                if not next_item.is_ready():
+                    self.async_download(next_item)
 
                 break
             except ValidationFailedError as e:
                 self.send_channel_msg(e.msg)
-                self.playlist.remove_by_id(next.id)
-                self.cache.free_and_delete(next.id)
+                self.playlist.remove_by_id(next_item.id)
+                self.cache.free_and_delete(next_item.id)
 
     def async_download(self, item: CachedItemWrapper) -> threading.Thread:
         th = threading.Thread(

--- a/src/botamusique/mumbleBot.py
+++ b/src/botamusique/mumbleBot.py
@@ -20,7 +20,6 @@ from typing import Callable, Any
 
 import audioop
 
-from botamusique import interface
 from botamusique import util
 from botamusique.constants import tr_cli as tr
 from botamusique.database import SettingsDatabase, MusicDatabase
@@ -802,29 +801,3 @@ class MumbleBot:
 
         self.wait_for_ready = True
         self.pause_at_id = ""
-
-
-def start_web_interface(addr: str, port: int, bot: MumbleBot) -> None:
-    global formatter
-
-    # setup logger
-    werkzeug_logger = logging.getLogger('werkzeug')
-    werkzeug_logger.propagate = False
-    logfile = util.solve_filepath(bot.config.get('webinterface', 'web_logfile'))
-    if logfile:
-        handler = logging.handlers.RotatingFileHandler(logfile, mode='a', maxBytes=10240, backupCount=3)  # Rotate after 10KB, leave 3 old logs
-    else:
-        handler = logging.StreamHandler()
-
-    # replace werkzeug_logger handlers with ours
-    for handler in list(werkzeug_logger.handlers):
-        if isinstance(handler, logging.StreamHandler):
-            werkzeug_logger.removeHandler(handler)
-            handler.close()
-    werkzeug_logger.addHandler(handler)
-
-    interface.init_app()
-    interface.set_bot(bot)
-    interface.init_proxy()
-    interface.web.secret_key = bot.config.get('webinterface', 'flask_secret')
-    interface.web.run(port=port, host=addr)

--- a/src/botamusique/mumbleBot.py
+++ b/src/botamusique/mumbleBot.py
@@ -5,6 +5,7 @@ import logging.handlers
 import math
 import os
 import os.path
+import queue
 import re
 import signal
 import struct
@@ -68,7 +69,7 @@ class MumbleBot:
 
         # Related to ffmpeg thread
         self.thread = None
-        self.thread_stderr = None
+        self._stderr_queue: queue.Queue[str] = queue.Queue()
         self.read_pcm_size = 0
         self.pcm_buffer_size = 0
         self.last_ffmpeg_err = ""
@@ -488,15 +489,17 @@ class MumbleBot:
                    uri, '-ss', f"{start_from:f}", '-ac', str(channels), '-f', 's16le', '-ar', '48000', '-')
         self.log.debug("bot: execute ffmpeg command: " + " ".join(command))
 
-        # The ffmpeg process is a thread
-        # prepare pipe for catching stderr of ffmpeg
+        self._stderr_queue = queue.Queue()
+        self.thread = sp.Popen(command, stdout=sp.PIPE,
+                               stderr=sp.PIPE if self.redirect_ffmpeg_log else None,
+                               bufsize=self.pcm_buffer_size)
         if self.redirect_ffmpeg_log:
-            pipe_rd, pipe_wd = util.pipe_no_wait()  # Let the pipe work in non-blocking mode
-            self.thread_stderr = os.fdopen(pipe_rd)
-        else:
-            pipe_rd, pipe_wd = None, None
+            th = threading.Thread(target=self._drain_stderr, args=(self.thread,), daemon=True)
+            th.start()
 
-        self.thread = sp.Popen(command, stdout=sp.PIPE, stderr=pipe_wd, bufsize=self.pcm_buffer_size)
+    def _drain_stderr(self, proc: sp.Popen) -> None:
+        for line in proc.stderr:
+            self._stderr_queue.put(line.decode(errors='replace'))
 
     def async_download_next(self) -> None:
         # Function start if the next music isn't ready
@@ -579,10 +582,9 @@ class MumbleBot:
 
                 if self.redirect_ffmpeg_log:
                     try:
-                        self.last_ffmpeg_err = self.thread_stderr.readline()
-                        if self.last_ffmpeg_err:
-                            self.log.debug("ffmpeg: " + self.last_ffmpeg_err.strip("\n"))
-                    except:
+                        self.last_ffmpeg_err = self._stderr_queue.get_nowait()
+                        self.log.debug("ffmpeg: " + self.last_ffmpeg_err.strip("\n"))
+                    except queue.Empty:
                         pass
 
                 if raw_music:

--- a/src/botamusique/util.py
+++ b/src/botamusique/util.py
@@ -193,8 +193,7 @@ def get_url_from_input(string: str) -> str:
         else:
             return ""
 
-    match = re.search("(http|https)://(\\S*)?/(\\S*)", string, flags=re.IGNORECASE)
-    if match:
+    if match := re.search("(http|https)://(\\S*)?/(\\S*)", string, flags=re.IGNORECASE):
         url = match[1].lower() + "://" + match[2].lower() + "/" + match[3]
         # https://github.com/mumble-voip/mumble/issues/4999
         return html.unescape(url)
@@ -257,8 +256,7 @@ def get_media_duration(path: str) -> float:
 
 
 def parse_time(human: str) -> float:
-    match = re.search("(?:(\\d\\d):)?(?:(\\d\\d):)?(\\d+(?:\\.\\d*)?)", human, flags=re.IGNORECASE)
-    if match:
+    if match := re.search("(?:(\\d\\d):)?(?:(\\d\\d):)?(\\d+(?:\\.\\d*)?)", human, flags=re.IGNORECASE):
         if match[1] is None and match[2] is None:
             return float(match[3])
         elif match[2] is None:
@@ -280,8 +278,7 @@ def format_time(seconds: float) -> str:
 def parse_file_size(human: str) -> int:
     units = {"B": 1, "KB": 1024, "MB": 1024 * 1024, "GB": 1024 * 1024 * 1024, "TB": 1024 * 1024 * 1024 * 1024,
              "K": 1024, "M": 1024 * 1024, "G": 1024 * 1024 * 1024, "T": 1024 * 1024 * 1024 * 1024}
-    match = re.search("(\\d+(?:\\.\\d*)?)\\s*([A-Za-z]+)", human, flags=re.IGNORECASE)
-    if match:
+    if match := re.search("(\\d+(?:\\.\\d*)?)\\s*([A-Za-z]+)", human, flags=re.IGNORECASE):
         num = float(match[1])
         unit = match[2].upper()
         if unit in units:

--- a/src/botamusique/util.py
+++ b/src/botamusique/util.py
@@ -4,10 +4,11 @@
 import hashlib
 import html
 import io
+import json
 import logging
 import os
 import re
-import subprocess as sp
+import subprocess
 import sys
 import traceback
 import zipfile
@@ -85,7 +86,7 @@ def update(current_version: str, config: ConfigParser) -> str:
     msg = ""
 
     log.info(f'update: starting update {YT_PKG_NAME} via pip3')
-    tp = sp.check_output([config.get('bot', 'pip3_path'), 'install', '--upgrade', YT_PKG_NAME]).decode()
+    tp = subprocess.check_output([config.get('bot', 'pip3_path'), 'install', '--upgrade', YT_PKG_NAME]).decode()
     if f"Collecting {YT_PKG_NAME}" in tp.splitlines():
         msg += "Update done: " + tp.split('Successfully installed')[1]
     else:
@@ -102,7 +103,6 @@ def pipe_no_wait() -> tuple[int, int] | tuple[None, None]:
 
     if platform == "linux" or platform == "linux2" or platform == "darwin" or platform.startswith("openbsd") or platform.startswith("freebsd"):
         import fcntl
-        import os
 
         pipe_rd = 0
         pipe_wd = 0
@@ -123,7 +123,6 @@ def pipe_no_wait() -> tuple[int, int] | tuple[None, None]:
     elif platform == "win32":
         # https://stackoverflow.com/questions/34504970/non-blocking-read-on-os-pipe-on-windows
         import msvcrt
-        import os
 
         from ctypes import windll, byref, wintypes, WinError, POINTER
         from ctypes.wintypes import HANDLE, DWORD, BOOL
@@ -256,7 +255,6 @@ def get_url_from_input(string: str) -> str:
 
 def youtube_search(query: str, config: ConfigParser) -> list[list[str]] | bool:
     global log
-    import json
 
     try:
         cookie_file = config.get('youtube_dl', 'cookie_file')
@@ -297,7 +295,7 @@ def youtube_search(query: str, config: ConfigParser) -> list[list[str]] | bool:
 def get_media_duration(path: str) -> float:
     command = ("ffprobe", "-v", "quiet", "-show_entries", "format=duration",
                "-of", "default=noprint_wrappers=1:nokey=1", path)
-    process = sp.Popen(command, stdout=sp.PIPE, stderr=sp.PIPE)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = process.communicate()
 
     try:
@@ -383,7 +381,6 @@ def set_logging_formatter(handler: logging.Handler, logging_level: int) -> None:
 
 
 def get_snapshot_version() -> str:
-    import subprocess
     wd = os.getcwd()
     root_dir = os.path.dirname(__file__)
     os.chdir(root_dir)

--- a/src/botamusique/util.py
+++ b/src/botamusique/util.py
@@ -9,12 +9,10 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import traceback
 import zipfile
 from configparser import ConfigParser
 from importlib import reload
-from sys import platform
 from typing import Any
 
 import requests
@@ -95,55 +93,6 @@ def update(current_version: str, config: ConfigParser) -> str:
     reload(youtube_dl)
     msg += "<br/>" + YT_PKG_NAME.capitalize() + " reloaded"
     return msg
-
-
-def pipe_no_wait() -> tuple[int, int] | tuple[None, None]:
-    """ Generate a non-block pipe used to fetch the STDERR of ffmpeg.
-    """
-
-    if platform == "linux" or platform == "linux2" or platform == "darwin" or platform.startswith("openbsd") or platform.startswith("freebsd"):
-        import fcntl
-
-        pipe_rd = 0
-        pipe_wd = 0
-
-        if hasattr(os, "pipe2"):
-            pipe_rd, pipe_wd = os.pipe2(os.O_NONBLOCK)
-        else:
-            pipe_rd, pipe_wd = os.pipe()
-
-            try:
-                fl = fcntl.fcntl(pipe_rd, fcntl.F_GETFL)
-                fcntl.fcntl(pipe_rd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
-            except:
-                print(sys.exc_info()[1])
-                return None, None
-        return pipe_rd, pipe_wd
-
-    elif platform == "win32":
-        # https://stackoverflow.com/questions/34504970/non-blocking-read-on-os-pipe-on-windows
-        import msvcrt
-
-        from ctypes import windll, byref, wintypes, WinError, POINTER
-        from ctypes.wintypes import HANDLE, DWORD, BOOL
-
-        pipe_rd, pipe_wd = os.pipe()
-
-        LPDWORD = POINTER(DWORD)
-        PIPE_NOWAIT = wintypes.DWORD(0x00000001)
-        ERROR_NO_DATA = 232
-
-        SetNamedPipeHandleState = windll.kernel32.SetNamedPipeHandleState
-        SetNamedPipeHandleState.argtypes = [HANDLE, LPDWORD, LPDWORD, LPDWORD]
-        SetNamedPipeHandleState.restype = BOOL
-
-        h = msvcrt.get_osfhandle(pipe_rd)
-
-        res = windll.kernel32.SetNamedPipeHandleState(h, byref(PIPE_NOWAIT), None, None)
-        if res == 0:
-            print(WinError())
-            return None, None
-        return pipe_rd, pipe_wd
 
 
 class Dir(object):

--- a/src/pymumble_py3/soundqueue.py
+++ b/src/pymumble_py3/soundqueue.py
@@ -5,7 +5,7 @@ from threading import Lock
 
 import opuslib_next
 
-from pymumble_constants import *
+from pymumble_py3.pymumble_constants import *
 
 
 class SoundQueue:

--- a/src/pymumble_py3/soundqueue.py
+++ b/src/pymumble_py3/soundqueue.py
@@ -112,8 +112,8 @@ class SoundQueue:
 class SoundChunk:
     """
     Object that contains the actual audio frame, in PCM format"""    
-    def __init__(self, pcm: bytes, sequence: int, size: int, calculated_time: float, type: int, target: int, timestamp: float = time.time()) -> None:
-        self.timestamp = timestamp  # measured time of arrival of the sound 
+    def __init__(self, pcm: bytes, sequence: int, size: int, calculated_time: float, type: int, target: int, timestamp: float | None = None) -> None:
+        self.timestamp = timestamp if timestamp is not None else time.time()  # measured time of arrival of the sound
         self.time = calculated_time  # calculated time of arrival of the sound (based on sequence)
         self.pcm = pcm  # audio data
         self.sequence = sequence  # sequence of the packet

--- a/src/pymumble_py3/soundqueue.py
+++ b/src/pymumble_py3/soundqueue.py
@@ -2,6 +2,7 @@
 import time
 from collections import deque
 from threading import Lock
+from typing import Any
 
 import opuslib_next
 
@@ -13,7 +14,7 @@ class SoundQueue:
     Per user storage of received audio frames
     Takes care of the decoding of the received audio
     """
-    def __init__(self, mumble_object):
+    def __init__(self, mumble_object: Any) -> None:
         self.mumble_object = mumble_object
         
         self.queue = deque()
@@ -30,14 +31,14 @@ class SoundQueue:
                     PYMUMBLE_AUDIO_TYPE_OPUS: opuslib_next.Decoder(PYMUMBLE_SAMPLERATE, 1)
         }
 
-    def set_receive_sound(self, value):
+    def set_receive_sound(self, value: bool) -> None:
         """Define if received sounds must be kept or discarded in this specific queue (user)"""
         if value:
             self.receive_sound = True
         else:
             self.receive_sound = False
 
-    def add(self, audio, sequence, type, target):
+    def add(self, audio: bytes, sequence: int, type: int, target: int) -> SoundChunk | None:
         """Add a new audio frame to the queue, after decoding"""
         if not self.receive_sound:
             return None
@@ -78,14 +79,14 @@ class SoundQueue:
             self.lock.release()
             self.mumble_object.Log.error("error while decoding audio. sequence:{seq}, type:{type}. {error}".format(seq=sequence, type=type, error=str(e)))
 
-    def is_sound(self):
+    def is_sound(self) -> bool:
         """Boolean to check if there is a sound frame in the queue"""
         if len(self.queue) > 0:
             return True
         else:
             return False
         
-    def get_sound(self, duration=None):
+    def get_sound(self, duration: float | None = None) -> SoundChunk | None:
         """Return the first sound of the queue and discard it"""
         self.lock.acquire()
 
@@ -100,7 +101,7 @@ class SoundQueue:
         self.lock.release()
         return result
     
-    def first_sound(self):
+    def first_sound(self) -> SoundChunk | None:
         """Return the first sound of the queue, but keep it"""
         if len(self.queue) > 0:
             return self.queue[-1]
@@ -111,7 +112,7 @@ class SoundQueue:
 class SoundChunk:
     """
     Object that contains the actual audio frame, in PCM format"""    
-    def __init__(self, pcm, sequence, size, calculated_time, type, target, timestamp=time.time()):
+    def __init__(self, pcm: bytes, sequence: int, size: int, calculated_time: float, type: int, target: int, timestamp: float = time.time()) -> None:
         self.timestamp = timestamp  # measured time of arrival of the sound 
         self.time = calculated_time  # calculated time of arrival of the sound (based on sequence)
         self.pcm = pcm  # audio data
@@ -121,7 +122,7 @@ class SoundChunk:
         self.type = type  # type of the audio (codec)
         self.target = target  # target of the audio
         
-    def extract_sound(self, duration):
+    def extract_sound(self, duration: float) -> SoundChunk:
         """Extract part of the chunk, leaving a valid chunk for the remaining part"""
         size = int(duration*2*PYMUMBLE_SAMPLERATE)
         result = SoundChunk(

--- a/src/pymumble_py3/users.py
+++ b/src/pymumble_py3/users.py
@@ -3,6 +3,7 @@ from threading import Lock
 
 import pymumble_py3.messages as messages
 import pymumble_py3.mumble_pb2 as mumble_pb2
+from pymumble_py3 import soundqueue
 from pymumble_py3.errors import TextTooLongError, ImageTooBigError
 from pymumble_py3.pymumble_constants import *
 
@@ -67,7 +68,6 @@ class User(dict):
         self.update(message)
 
         if mumble_object.receive_sound:
-            from . import soundqueue
             self.sound = soundqueue.SoundQueue(self.mumble_object)  # will hold this user incoming audio
         else:
             self.sound = None

--- a/src/pymumble_py3/users.py
+++ b/src/pymumble_py3/users.py
@@ -60,6 +60,7 @@ class User(dict):
     """Object that store one user"""
 
     def __init__(self, mumble_object, message):
+        super().__init__()
         self.mumble_object = mumble_object
         self["session"] = message.session
         self["channel_id"] = 0

--- a/src/pymumble_py3/users.py
+++ b/src/pymumble_py3/users.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from threading import Lock
+from typing import Any
 
 import pymumble_py3.messages as messages
 import pymumble_py3.mumble_pb2 as mumble_pb2
@@ -11,7 +12,7 @@ from pymumble_py3.pymumble_constants import *
 class Users(dict):
     """Object that stores and update all connected users"""
 
-    def __init__(self, mumble_object, callbacks):
+    def __init__(self, mumble_object: Any, callbacks: Any) -> None:
         super().__init__()
         self.mumble_object = mumble_object
         self.callbacks = callbacks
@@ -20,7 +21,7 @@ class Users(dict):
         self.myself_session = None  # session number of the pymumble thread itself
         self.lock = Lock()
 
-    def update(self, message):
+    def update(self, message: Any) -> None:
         """Update a user information, based on the incoming message"""
         self.lock.acquire()
 
@@ -60,7 +61,7 @@ class Users(dict):
 class User(dict):
     """Object that store one user"""
 
-    def __init__(self, mumble_object, message):
+    def __init__(self, mumble_object: Any, message: Any) -> None:
         super().__init__()
         self.mumble_object = mumble_object
         self["session"] = message.session
@@ -72,7 +73,7 @@ class User(dict):
         else:
             self.sound = None
 
-    def update(self, message):
+    def update(self, message: Any) -> dict[str, Any]:
         """Update user state, based on an incoming message"""
         actions = dict()
 
@@ -97,7 +98,7 @@ class User(dict):
 
         return actions  # return a dict, useful for the callback functions
 
-    def update_field(self, name, field):
+    def update_field(self, name: str, field: Any) -> dict[str, Any]:
         """Update one state value for a user"""
         actions = dict()
         if name not in self or self[name] != field:
@@ -106,7 +107,7 @@ class User(dict):
 
         return actions
 
-    def get_property(self, property):
+    def get_property(self, property: str) -> Any:
         if property in self:
             return self[property]
         else:

--- a/tests/test_media_playlist.py
+++ b/tests/test_media_playlist.py
@@ -128,21 +128,21 @@ class TestOneshotCurrentAndNext:
         _add_items(oneshot, mock_cache, 2)
         assert oneshot.current_index == -1
         result = oneshot.current_item()
-        assert result is not False
+        assert result is not None
 
     def test_next_advances_and_removes_current(self, oneshot, mock_cache):
         _add_items(oneshot, mock_cache, 2)
         first = oneshot.next()   # sets index=0, returns self[0]
-        assert first is not False
+        assert first is not None
         second = oneshot.next()  # deletes old self[0], returns new self[0]
-        assert second is not False
-        third = oneshot.next()   # list now empty → False
+        assert second is not None
+        third = oneshot.next()   # list now empty → None
         assert third is None
 
     def test_next_on_single_item_returns_false_after(self, oneshot, mock_cache):
         _add_items(oneshot, mock_cache, 1)
         oneshot.next()           # sets index=0, returns item
-        result = oneshot.next()  # deletes item, list empty → False
+        result = oneshot.next()  # deletes item, list empty → None
         assert result is None
 
 
@@ -306,8 +306,8 @@ class TestRepeatPlaylist:
         _add_items(repeat_playlist, mock_cache, 2)
         first = repeat_playlist.next()
         second = repeat_playlist.next()
-        assert first is not False
-        assert second is not False
+        assert first is not None
+        assert second is not None
         assert first is not second
 
     def test_next_wraps_around(self, repeat_playlist, mock_cache):
@@ -335,7 +335,7 @@ class TestRandomPlaylist:
     def test_next_returns_items(self, random_playlist, mock_cache):
         _add_items(random_playlist, mock_cache, 3)
         results = [random_playlist.next() for _ in range(3)]
-        assert all(r is not False for r in results)
+        assert all(r is not None for r in results)
 
     def test_next_wraps_around_with_reshuffling(self, random_playlist, mock_cache):
         """After exhausting all items, next() reshuffles and returns an item."""
@@ -343,7 +343,7 @@ class TestRandomPlaylist:
         random_playlist.next()  # index 0
         random_playlist.next()  # index 1 (end)
         fourth = random_playlist.next()  # re-shuffle, index 0
-        assert fourth is not False
+        assert fourth is not None
 
     def test_next_empty_returns_false(self, random_playlist):
         assert random_playlist.next() is None

--- a/tests/test_media_playlist.py
+++ b/tests/test_media_playlist.py
@@ -74,13 +74,13 @@ class TestEmptyPlaylist:
         assert oneshot.is_empty() is True
 
     def test_next_returns_false(self, oneshot):
-        assert oneshot.next() is False
+        assert oneshot.next() is None
 
     def test_current_item_returns_false(self, oneshot):
-        assert oneshot.current_item() is False
+        assert oneshot.current_item() is None
 
-    def test_next_item_returns_false(self, oneshot):
-        assert oneshot.next_item() is False
+    def test_next_item_returns_none(self, oneshot):
+        assert oneshot.next_item() is None
 
     def test_len_is_zero(self, oneshot):
         assert len(oneshot) == 0
@@ -137,13 +137,13 @@ class TestOneshotCurrentAndNext:
         second = oneshot.next()  # deletes old self[0], returns new self[0]
         assert second is not False
         third = oneshot.next()   # list now empty → False
-        assert third is False
+        assert third is None
 
     def test_next_on_single_item_returns_false_after(self, oneshot, mock_cache):
         _add_items(oneshot, mock_cache, 1)
         oneshot.next()           # sets index=0, returns item
         result = oneshot.next()  # deletes item, list empty → False
-        assert result is False
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -204,7 +204,7 @@ class TestRemove:
     def test_remove_returns_false_when_out_of_bounds(self, oneshot, mock_cache):
         _add_items(oneshot, mock_cache, 1)
         result = oneshot.remove(99)
-        assert result is False
+        assert result is None
 
     def test_remove_frees_cache_when_last_reference(self, oneshot, mock_cache):
         _add_items(oneshot, mock_cache, 1)
@@ -324,7 +324,7 @@ class TestRepeatPlaylist:
         assert first is wrapped
 
     def test_next_empty_returns_false(self, repeat_playlist):
-        assert repeat_playlist.next() is False
+        assert repeat_playlist.next() is None
 
 
 # ---------------------------------------------------------------------------
@@ -346,7 +346,7 @@ class TestRandomPlaylist:
         assert fourth is not False
 
     def test_next_empty_returns_false(self, random_playlist):
-        assert random_playlist.next() is False
+        assert random_playlist.next() is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
drop from __future__ import annotations and TYPE_CHECKING guards (resolved via proper import restructuring), replace | bool sentinels with | None throughout the playlist, swap the platform-specific non-blocking pipe for a cross-platform queue.Queue stderr drain,
  ▎  move mid-function imports to the top, add missing type hints, apply the walrus operator where idiomatic, and fix several pre-existing bugs (mutable default in SoundChunk, variable shadowing in start_web_interface, double next_item() call in async_download_next).