### PR TITLE
feat: add type hints across pymumble_py3 and botamusique

### DIFF
--- a/src/botamusique/command.py
+++ b/src/botamusique/command.py
@@ -589,7 +589,7 @@ def cmd_yt_search(bot: MumbleBot, user: str, text: Any, command: str, parameter:
         bot.send_msg(tr('bad_parameter', command=command), text)
 
 
-def _yt_format_result(results, start, count):
+def _yt_format_result(results: list[tuple[str, str, str]], start: int, count: int) -> str:
     msg = '<table><tr><th width="10%">Index</th><th>Title</th><th width="20%">Uploader</th></tr>'
     for index, item in enumerate(results[start:start + count]):
         msg += '<tr><td>{index:d}</td><td>{title}</td><td>{uploader}</td></tr>'.format(

--- a/src/botamusique/interface.py
+++ b/src/botamusique/interface.py
@@ -128,7 +128,7 @@ banned_ip = []
 
 def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
-    def decorated(*args, **kwargs):
+    def decorated(*args: Any, **kwargs: Any) -> Any:
         global log, user, bad_access_count, banned_ip
 
         if request.remote_addr in banned_ip:
@@ -197,7 +197,7 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
     return decorated
 
 
-def tag_color(tag):
+def tag_color(tag: str) -> str:
     num = hash(tag) % 8
     if num == 0:
         return "primary"
@@ -217,7 +217,7 @@ def tag_color(tag):
         return "dark"
 
 
-def build_tags_color_lookup():
+def build_tags_color_lookup() -> dict[str, str]:
     color_lookup = {}
     for tag in _bot.music_db.query_all_tags():
         color_lookup[tag] = tag_color(tag)
@@ -225,7 +225,7 @@ def build_tags_color_lookup():
     return color_lookup
 
 
-def get_all_dirs():
+def get_all_dirs() -> list[str]:
     dirs = ["."]
     paths = _bot.music_db.query_all_paths()
     for path in paths:
@@ -243,7 +243,7 @@ def get_all_dirs():
 
 @bp.route("/", methods=["GET"])
 @requires_auth
-def index():
+def index() -> str:
     return open(
         root_dir.joinpath(
             f"web/templates/index.{_bot.config.get('bot', 'language')}.html"
@@ -254,7 +254,7 @@ def index():
 
 @bp.route("/playlist", methods=['GET'])
 @requires_auth
-def playlist():
+def playlist() -> Response:
     if len(_bot.playlist) == 0:
         return jsonify({
             'items': [],
@@ -330,7 +330,7 @@ def playlist():
     })
 
 
-def status():
+def status() -> Response:
     if len(_bot.playlist) > 0:
         return jsonify({'ver': _bot.playlist.version,
                         'current_index': _bot.playlist.current_index,
@@ -354,7 +354,7 @@ def status():
 
 @bp.route("/post", methods=['POST'])
 @requires_auth
-def post():
+def post() -> Response:
     global log
 
     payload = request.get_json() if request.is_json else request.form
@@ -533,7 +533,7 @@ def post():
     return status()
 
 
-def build_library_query_condition(form):
+def build_library_query_condition(form: dict[str, Any]) -> Condition:
     try:
         condition = Condition()
 
@@ -574,7 +574,7 @@ def build_library_query_condition(form):
 
 @bp.route("/library/info", methods=['GET'])
 @requires_auth
-def library_info():
+def library_info() -> Response:
     global log
 
     while _bot.cache.dir_lock.locked():
@@ -594,7 +594,7 @@ def library_info():
 
 @bp.route("/library", methods=['POST'])
 @requires_auth
-def library():
+def library() -> Response:
     global log
     ITEM_PER_PAGE = 10
 
@@ -704,7 +704,7 @@ def library():
 
 @bp.route('/upload', methods=["POST"])
 @requires_auth
-def upload():
+def upload() -> tuple[str, int]:
     global log
 
     if not _bot.config.getboolean("webinterface", "upload_enabled"):
@@ -756,7 +756,7 @@ def upload():
 
 @bp.route('/download', methods=["GET"])
 @requires_auth
-def download():
+def download() -> Response:
     global log
 
     if 'id' in request.args and request.args['id']:

--- a/src/pymumble_py3/blobs.py
+++ b/src/pymumble_py3/blobs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import struct
+from typing import Any
 
 from pymumble_py3.mumble_pb2 import RequestBlob
 from pymumble_py3.pymumble_constants import PYMUMBLE_MSG_TYPES_REQUESTBLOB
@@ -9,11 +10,11 @@ class Blobs(dict):
     """
     Manage the Blob library
     """
-    def __init__(self, mumble_object):
+    def __init__(self, mumble_object: Any) -> None:
         super().__init__()
         self.mumble_object = mumble_object
-        
-    def get_user_comment(self, hash):
+
+    def get_user_comment(self, hash: bytes) -> None:
         """Request the comment of a user"""
         if hash in self:
             return
@@ -22,7 +23,7 @@ class Blobs(dict):
         
         self.mumble_object.send_message(PYMUMBLE_MSG_TYPES_REQUESTBLOB, request)
     
-    def get_user_texture(self, hash):
+    def get_user_texture(self, hash: bytes) -> None:
         """Request the image of a user"""
         if hash in self:
             return
@@ -32,7 +33,7 @@ class Blobs(dict):
         
         self.mumble_object.send_message(PYMUMBLE_MSG_TYPES_REQUESTBLOB, request)
     
-    def get_channel_description(self, hash):
+    def get_channel_description(self, hash: bytes) -> None:
         """Request the description/comment of a channel"""
         if hash in self:
             return

--- a/src/pymumble_py3/callbacks.py
+++ b/src/pymumble_py3/callbacks.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import threading
+from collections.abc import Callable
+from typing import Any
+
 from pymumble_py3.errors import UnknownCallbackError
 from pymumble_py3.pymumble_constants import *
-import threading
 
 
 class CallBacks(dict):
@@ -13,7 +16,7 @@ class CallBacks(dict):
     The call is done from within the pymumble loop thread, it's important to
     keep processing short to avoid delays on audio transmission
     """
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.update({
             PYMUMBLE_CLBK_CONNECTED: None,  # Connection succeeded
@@ -32,14 +35,14 @@ class CallBacks(dict):
             PYMUMBLE_CLBK_PERMISSIONQUERY: None
         })
 
-    def set_callback(self, callback, dest):
+    def set_callback(self, callback: str, dest: Callable[..., Any]) -> None:
         """Define the function to call for a specific callback.  Suppress any existing callback function"""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
 
         self[callback] = [dest]
 
-    def add_callback(self, callback, dest):
+    def add_callback(self, callback: str, dest: Callable[..., Any]) -> None:
         """Add the function to call for a specific callback."""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
@@ -48,14 +51,14 @@ class CallBacks(dict):
             self[callback] = list()
         self[callback].append(dest)
 
-    def get_callback(self, callback):
+    def get_callback(self, callback: str) -> list[Callable[..., Any]] | None:
         """Get the functions assigned to a callback as a list. Return None if no callback defined"""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
 
         return self[callback]
 
-    def remove_callback(self, callback, dest):
+    def remove_callback(self, callback: str, dest: Callable[..., Any]) -> None:
         """Remove a specific function from a specific callback.  Function object must be the one added before."""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
@@ -67,14 +70,14 @@ class CallBacks(dict):
         if len(self[callback]) == 0:
             self[callback] = None
 
-    def reset_callback(self, callback):
+    def reset_callback(self, callback: str) -> None:
         """remove functions for a defined callback"""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
 
         self[callback] = None
 
-    def call_callback(self, callback, *pos_parameters):
+    def call_callback(self, callback: str, *pos_parameters: Any) -> None:
         """Call all the registered function for a specific callback."""
         if callback not in self:
             raise UnknownCallbackError("Callback \"%s\" does not exists." % callback)
@@ -87,10 +90,10 @@ class CallBacks(dict):
                 else:
                     func(*pos_parameters)
 
-    def __call__(self, callback, *pos_parameters):
+    def __call__(self, callback: str, *pos_parameters: Any) -> None:
         """shortcut to be able to call the dict element as a function"""
         self.call_callback(callback, *pos_parameters)
 
-    def get_callbacks_list(self):
+    def get_callbacks_list(self) -> list[str]:
         """Get a list of all callbacks"""
         return list(self.keys())

--- a/src/pymumble_py3/channels.py
+++ b/src/pymumble_py3/channels.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from threading import Lock
+from typing import Any
 
 import pymumble_py3.messages as messages
 from pymumble_py3.acl import ACL
@@ -12,14 +13,14 @@ class Channels(dict):
     Object that Stores all channels and their properties.
     """
 
-    def __init__(self, mumble_object, callbacks):
+    def __init__(self, mumble_object: Any, callbacks: Any) -> None:
         super().__init__()
         self.mumble_object = mumble_object
         self.callbacks = callbacks
 
         self.lock = Lock()
 
-    def update(self, message):
+    def update(self, message: Any) -> None:
         """Update the channel information based on an incoming message"""
         self.lock.acquire()
 
@@ -32,7 +33,7 @@ class Channels(dict):
 
         self.lock.release()
 
-    def remove(self, id):
+    def remove(self, id: int) -> None:
         """Delete a channel when server signal the channel is removed"""
         self.lock.acquire()
 
@@ -43,7 +44,7 @@ class Channels(dict):
 
         self.lock.release()
 
-    def find_by_tree(self, tree):
+    def find_by_tree(self, tree: list[str]) -> dict[str, Any]:
         """Find a channel by its full path (a list with an element for each leaf)"""
         if not getattr(tree, '__iter__', False):
             tree = tree  # function use argument as a list
@@ -64,7 +65,7 @@ class Channels(dict):
 
         return current
 
-    def get_childs(self, channel):
+    def get_childs(self, channel: dict[str, Any]) -> list[dict[str, Any]]:
         """Get the child channels of a channel in a list"""
         childs = list()
 
@@ -74,7 +75,7 @@ class Channels(dict):
 
         return childs
 
-    def get_descendants(self, channel):
+    def get_descendants(self, channel: dict[str, Any]) -> list[list[dict[str, Any]]]:
         """Get all the descendant of a channel, in nested lists"""
         descendants = list()
 
@@ -83,7 +84,7 @@ class Channels(dict):
 
         return descendants
 
-    def get_tree(self, channel):
+    def get_tree(self, channel: dict[str, Any]) -> list[dict[str, Any]]:
         """Get the whole list of channels, in a multidimensional list"""
         tree = list()
 
@@ -97,7 +98,7 @@ class Channels(dict):
 
         return tree
 
-    def find_by_name(self, name):
+    def find_by_name(self, name: str) -> dict[str, Any]:
         """Find a channel by name.  Stop on the first that match"""
         if name == "":
             return self[0]
@@ -109,15 +110,15 @@ class Channels(dict):
         err = "Channel %s does not exists" % name
         raise UnknownChannelError(err)
 
-    def new_channel(self, parent_id, name, temporary=False):
+    def new_channel(self, parent_id: int, name: str, temporary: bool = False) -> None:
         cmd = messages.CreateChannel(parent_id, name, temporary)
         self.mumble_object.execute_command(cmd)
 
-    def remove_channel(self, channel_id):
+    def remove_channel(self, channel_id: int) -> None:
         cmd = messages.RemoveChannel(channel_id)
         self.mumble_object.execute_command(cmd)
 
-    def unlink_every_channel(self):
+    def unlink_every_channel(self) -> None:
         """
         Unlink every channels in server.
         So there will be no channel linked to other channel.
@@ -133,21 +134,21 @@ class Channel(dict):
     Stores information about one specific channel
     """
 
-    def __init__(self, mumble_object, message):
+    def __init__(self, mumble_object: Any, message: Any) -> None:
         self.mumble_object = mumble_object
         self["channel_id"] = message.channel_id
         self.acl = ACL(mumble_object=mumble_object, channel_id=self["channel_id"])
         self.permissions = None  # populated from PermissionQuery messages
         self.update(message)
 
-    def get_users(self):
+    def get_users(self) -> list[dict[str, Any]]:
         users = []
         for user in list(self.mumble_object.users.values()):
             if user["channel_id"] == self["channel_id"]:
                 users.append(user)
         return users
 
-    def update(self, message):
+    def update(self, message: Any) -> dict[str, Any]:
         """Update a channel based on an incoming message"""
         actions = dict()
 
@@ -165,7 +166,7 @@ class Channel(dict):
 
         return actions  # return a dict with updates performed, useful for the callback functions
 
-    def update_acl(self, message):
+    def update_acl(self, message: Any) -> None:
         self.acl.update(message)
 
     def update_permissions(self, permissions: int) -> None:
@@ -181,10 +182,10 @@ class Channel(dict):
             return None
         return bool(self.permissions & permission)
 
-    def get_id(self):
+    def get_id(self) -> int:
         return self["channel_id"]
 
-    def update_field(self, name, field):
+    def update_field(self, name: str, field: Any) -> dict[str, Any]:
         """Update one value"""
         actions = dict()
         if name not in self or self[name] != field:
@@ -193,13 +194,13 @@ class Channel(dict):
 
         return actions  # return a dict with updates performed, useful for the callback functions
 
-    def get_property(self, property):
+    def get_property(self, property: str) -> Any:
         if property in self:
             return self[property]
         else:
             return None
 
-    def move_in(self, session=None):
+    def move_in(self, session: int | None = None) -> None:
         """Ask to move a session in a specific channel.  By default move pymumble own session"""
         if session is None:
             session = self.mumble_object.users.myself_session
@@ -207,11 +208,11 @@ class Channel(dict):
         cmd = messages.MoveCmd(session, self["channel_id"])
         self.mumble_object.execute_command(cmd)
 
-    def remove(self):
+    def remove(self) -> None:
         cmd = messages.RemoveChannel(self["channel_id"])
         self.mumble_object.execute_command(cmd)
 
-    def send_text_message(self, message):
+    def send_text_message(self, message: str) -> None:
         """Send a text message to the channel."""
 
         # TODO: This check should be done inside execute_command()
@@ -229,23 +230,23 @@ class Channel(dict):
         cmd = messages.TextMessage(session, self["channel_id"], message)
         self.mumble_object.execute_command(cmd)
 
-    def link(self, channel_id):
+    def link(self, channel_id: int) -> None:
         """Link selected channel with other channel"""
         cmd = messages.LinkChannel({"channel_id": self["channel_id"], "add_id": channel_id})
         self.mumble_object.execute_command(cmd)
 
-    def unlink(self, channel_id):
+    def unlink(self, channel_id: int) -> None:
         """Unlink one channel which is linked to a specific channel."""
         cmd = messages.UnlinkChannel({"channel_id": self["channel_id"], "remove_ids": [channel_id]})
         self.mumble_object.execute_command(cmd)
 
-    def unlink_all(self):
+    def unlink_all(self) -> None:
         """Unlink all channels which is linked to a specific channel."""
         if "links" in self:
             cmd = messages.UnlinkChannel({"channel_id": self["channel_id"], "remove_ids": self["links"]})
             self.mumble_object.execute_command(cmd)
 
-    def rename_channel(self, name):
+    def rename_channel(self, name: str) -> None:
         params = {
             'channel_id': self['channel_id'],
             'name': name
@@ -253,7 +254,7 @@ class Channel(dict):
         cmd = messages.UpdateChannel(params)
         self.mumble_object.execute_command(cmd)
 
-    def move_channel(self, new_parent_id):
+    def move_channel(self, new_parent_id: int) -> None:
         params = {
             'channel_id': self['channel_id'],
             'parent': new_parent_id
@@ -261,7 +262,7 @@ class Channel(dict):
         cmd = messages.UpdateChannel(params)
         self.mumble_object.execute_command(cmd)
 
-    def set_channel_position(self, position):
+    def set_channel_position(self, position: int) -> None:
         params = {
             'channel_id': self['channel_id'],
             'position': position
@@ -269,7 +270,7 @@ class Channel(dict):
         cmd = messages.UpdateChannel(params)
         self.mumble_object.execute_command(cmd)
 
-    def set_channel_max_users(self, max_users):
+    def set_channel_max_users(self, max_users: int) -> None:
         params = {
             'channel_id': self['channel_id'],
             'max_users': max_users
@@ -277,7 +278,7 @@ class Channel(dict):
         cmd = messages.UpdateChannel(params)
         self.mumble_object.execute_command(cmd)
 
-    def set_channel_description(self, description):
+    def set_channel_description(self, description: str) -> None:
         params = {
             'channel_id': self['channel_id'],
             'description': description
@@ -285,6 +286,6 @@ class Channel(dict):
         cmd = messages.UpdateChannel(params)
         self.mumble_object.execute_command(cmd)
 
-    def request_acl(self):
+    def request_acl(self) -> None:
         cmd = messages.QueryACL(self["channel_id"])
         self.mumble_object.execute_command(cmd)

--- a/src/pymumble_py3/errors.py
+++ b/src/pymumble_py3/errors.py
@@ -4,98 +4,98 @@
 class CodecNotSupportedError(Exception):
     """Thrown when receiving an audio packet from an unsupported codec"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class ConnectionRejectedError(Exception):
     """Thrown when server reject the connection"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class InvalidFormatError(Exception):
     """Thrown when receiving a packet not understood"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class UnknownCallbackError(Exception):
     """Thrown when asked for an unknown callback"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class UnknownChannelError(Exception):
     """Thrown when using an unknown channel"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class InvalidSoundDataError(Exception):
     """Thrown when trying to send an invalid audio pcm data"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class InvalidVarInt(Exception):
     """Thrown when trying to decode an invalid varint"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.value)
 
 
 class TextTooLongError(Exception):
     """Thrown when trying to send a message which is longer than allowed"""
 
-    def __init__(self, value):
+    def __init__(self, value: int) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'Maximum Text allowed length: {}'.format(self.value)
 
 
 class ImageTooBigError(Exception):
     """Thrown when trying to send a message or image which is longer than allowed"""
 
-    def __init__(self, value):
+    def __init__(self, value: int) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'Maximum Text/Image allowed length: {}'.format(self.value)
 
 
 class ACLChanGroupNotExist(Exception):
     """Thrown when trying to update an non-existant ACL ChanGroup"""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return 'ACL ChanGroup does not exist: {}'.format(self.value)

--- a/src/pymumble_py3/messages.py
+++ b/src/pymumble_py3/messages.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from threading import Lock
+from typing import Any
 
 from pymumble_py3.pymumble_constants import *
 
@@ -10,7 +11,7 @@ class Cmd:
     usually to forward to the murmur server
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.cmd_id = None
         self.lock = Lock()
 
@@ -22,7 +23,7 @@ class Cmd:
 class MoveCmd(Cmd):
     """Command to move a user from channel"""
 
-    def __init__(self, session, channel_id):
+    def __init__(self, session: int, channel_id: int) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_MOVE
@@ -33,7 +34,7 @@ class MoveCmd(Cmd):
 class TextMessage(Cmd):
     """Command to send a text message"""
 
-    def __init__(self, session, channel_id, message):
+    def __init__(self, session: int, channel_id: int, message: str) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_TEXTMESSAGE
@@ -45,7 +46,7 @@ class TextMessage(Cmd):
 class TextPrivateMessage(Cmd):
     """Command to send a private text message"""
 
-    def __init__(self, session, message):
+    def __init__(self, session: int, message: str) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_TEXTPRIVATEMESSAGE
@@ -56,7 +57,7 @@ class TextPrivateMessage(Cmd):
 class ModUserState(Cmd):
     """Command to change a user state"""
 
-    def __init__(self, session, params):
+    def __init__(self, session: int, params: dict[str, Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_MODUSERSTATE
@@ -66,7 +67,7 @@ class ModUserState(Cmd):
 class RemoveUser(Cmd):
     """Command to kick (ban=False) or ban (ban=True) a user"""
 
-    def __init__(self, session, params):
+    def __init__(self, session: int, params: dict[str, Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_REMOVEUSER
@@ -76,7 +77,7 @@ class RemoveUser(Cmd):
 class CreateChannel(Cmd):
     """Command to create channel"""
 
-    def __init__(self, parent, name, temporary):
+    def __init__(self, parent: int, name: str, temporary: bool) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_MSG_TYPES_CHANNELSTATE
@@ -88,7 +89,7 @@ class CreateChannel(Cmd):
 class RemoveChannel(Cmd):
     """Command to create channel"""
 
-    def __init__(self, channel_id):
+    def __init__(self, channel_id: int) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_MSG_TYPES_CHANNELREMOVE
@@ -98,7 +99,7 @@ class RemoveChannel(Cmd):
 class UpdateChannel(Cmd):
     """Command to update channel"""
 
-    def __init__(self, params):
+    def __init__(self, params: dict[str, Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_UPDATECHANNEL
@@ -108,7 +109,7 @@ class UpdateChannel(Cmd):
 class VoiceTarget(Cmd):
     """Command to create a whisper"""
 
-    def __init__(self, voice_id, targets):
+    def __init__(self, voice_id: int, targets: list[Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_MSG_TYPES_VOICETARGET
@@ -119,7 +120,7 @@ class VoiceTarget(Cmd):
 class LinkChannel(Cmd):
     """Command to link channel"""
 
-    def __init__(self, params):
+    def __init__(self, params: dict[str, Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_LINKCHANNEL
@@ -129,7 +130,7 @@ class LinkChannel(Cmd):
 class UnlinkChannel(Cmd):
     """Command to unlink channel"""
 
-    def __init__(self, params):
+    def __init__(self, params: dict[str, Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_UNLINKCHANNEL
@@ -139,7 +140,7 @@ class UnlinkChannel(Cmd):
 class QueryACL(Cmd):
     """Command to query ACL information for channel"""
 
-    def __init__(self, channel_id):
+    def __init__(self, channel_id: int) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_QUERYACL
@@ -149,7 +150,7 @@ class QueryACL(Cmd):
 class UpdateACL(Cmd):
     """Command to Update ACL information for channel"""
 
-    def __init__(self, channel_id, inherit_acls, chan_group, chan_acl):
+    def __init__(self, channel_id: int, inherit_acls: bool, chan_group: list[Any], chan_acl: list[Any]) -> None:
         Cmd.__init__(self)
 
         self.cmd = PYMUMBLE_CMD_UPDATEACL

--- a/src/pymumble_py3/mumble.py
+++ b/src/pymumble_py3/mumble.py
@@ -7,6 +7,7 @@ import struct
 import sys
 import threading
 import time
+from typing import Any
 
 import select
 
@@ -22,7 +23,7 @@ from pymumble_py3.errors import *
 from pymumble_py3.pymumble_constants import *
 
 
-def _wrap_socket(sock, keyfile=None, certfile=None, verify_mode=ssl.CERT_NONE, server_hostname=None):
+def _wrap_socket(sock: socket.socket, keyfile: str | None = None, certfile: str | None = None, verify_mode: ssl.VerifyMode = ssl.CERT_NONE, server_hostname: str | None = None) -> ssl.SSLSocket:
     try:
         ssl_context = ssl.create_default_context()
         if certfile:
@@ -43,7 +44,7 @@ class Mumble(threading.Thread):
     basically a thread
     """
 
-    def __init__(self, host, user, port=64738, password='', certfile=None, keyfile=None, reconnect=False, tokens=None, stereo=False, debug=False, client_type=0):
+    def __init__(self, host: str, user: str, port: int = 64738, password: str = '', certfile: str | None = None, keyfile: str | None = None, reconnect: bool = False, tokens: list[str] | None = None, stereo: bool = False, debug: bool = False, client_type: int = 0) -> None:
         """
         host=mumble server hostname or address
         port=mumble server port
@@ -107,7 +108,7 @@ class Mumble(threading.Thread):
 
         self.positional = None
 
-    def init_connection(self):
+    def init_connection(self) -> None:
         """Initialize variables that are local to a connection, (needed if the client automatically reconnect)"""
         self.ready_lock.acquire(False)  # reacquire the ready-lock in case of reconnection
 
@@ -136,7 +137,7 @@ class Mumble(threading.Thread):
         self.receive_buffer = bytes()  # initialize the control connection input buffer
         self.ping_stats = {"last_rcv": 0, "time_send": 0, "nb": 0, "avg": 40.0, "var": 0.0}  # Set / reset ping stats
 
-    def run(self):
+    def run(self) -> None:
         """Connect to the server and start the loop in its thread.  Retry if requested"""
         self.mumble_thread = threading.current_thread()
 
@@ -164,7 +165,7 @@ class Mumble(threading.Thread):
             self.callbacks(PYMUMBLE_CLBK_DISCONNECTED)
             time.sleep(PYMUMBLE_CONNECTION_RETRY_INTERVAL)
 
-    def connect(self):
+    def connect(self) -> int:
         """Connect to the server"""
         try:
             # Get IPv4/IPv6 server address
@@ -215,7 +216,7 @@ class Mumble(threading.Thread):
         self.connected = PYMUMBLE_CONN_STATE_AUTHENTICATING
         return self.connected
 
-    def loop(self):
+    def loop(self) -> None:
         """
         Main loop
         waiting for a message from the server for maximum self.loop_rate time
@@ -250,7 +251,7 @@ class Mumble(threading.Thread):
                 self.control_socket.close()
                 self.connected = PYMUMBLE_CONN_STATE_NOT_CONNECTED
 
-    def ping(self):
+    def ping(self) -> None:
         """Send the keepalive through available channels"""
         ping = mumble_pb2.Ping()
         ping.timestamp = int(time.time())
@@ -266,7 +267,7 @@ class Mumble(threading.Thread):
             self.Log.debug("Ping too long ! Disconnected ?")
             self.connected = PYMUMBLE_CONN_STATE_NOT_CONNECTED
 
-    def ping_response(self, mess):
+    def ping_response(self, mess: Any) -> None:
         self.ping_stats['last_rcv'] = int(time.time() * 1000)
         ping = int(time.time() * 1000) - self.ping_stats['time_send']
         old_avg = self.ping_stats['avg']
@@ -281,7 +282,7 @@ class Mumble(threading.Thread):
         self.ping_stats['avg'] = new_avg
         self.ping_stats['nb'] += 1
 
-    def send_message(self, type, message):
+    def send_message(self, type: int, message: Any) -> None:
         """Send a control message to the server"""
         packet = struct.pack("!HL", type, message.ByteSize()) + message.SerializeToString()
 
@@ -292,7 +293,7 @@ class Mumble(threading.Thread):
                 raise socket.error("Server socket error")
             packet = packet[sent:]
 
-    def read_control_messages(self):
+    def read_control_messages(self) -> None:
         """Read control messages coming from the server"""
         # from tools import tohex  # for debugging
 
@@ -321,7 +322,7 @@ class Mumble(threading.Thread):
 
             self.dispatch_control_message(type, message)
 
-    def dispatch_control_message(self, type, message):
+    def dispatch_control_message(self, type: int, message: bytes) -> None:
         """Dispatch control messages based on their type"""
         self.Log.debug("dispatch control message")
         if type == PYMUMBLE_MSG_TYPES_UDPTUNNEL:  # audio encapsulated in control message
@@ -492,7 +493,7 @@ class Mumble(threading.Thread):
                 elif items[0] == 'image_message_length':
                     self.server_max_image_message_length = int(items[1].strip())
 
-    def set_bandwidth(self, bandwidth):
+    def set_bandwidth(self, bandwidth: int) -> None:
         """Set the total allowed outgoing bandwidth"""
         if self.server_max_bandwidth is not None and bandwidth > self.server_max_bandwidth:
             self.bandwidth = self.server_max_bandwidth
@@ -502,7 +503,7 @@ class Mumble(threading.Thread):
         if self.sound_output:
             self.sound_output.set_bandwidth(self.bandwidth)  # communicate the update to the outgoing audio manager
 
-    def sound_received(self, message):
+    def sound_received(self, message: bytes) -> None:
         """Manage a received sound message"""
         # from tools import tohex  # for debugging
 
@@ -579,42 +580,42 @@ class Mumble(threading.Thread):
 
             pos += size  # go further in the packet, after the audio frame
         # TODO: get position info
-    def set_application_string(self, string):
+    def set_application_string(self, string: str) -> None:
         """Set the application name, that can be viewed by other clients on the server"""
         self.application = string
 
-    def set_loop_rate(self, rate):
+    def set_loop_rate(self, rate: float) -> None:
         """Set the current main loop rate (pause per iteration)"""
         self.loop_rate = rate
 
-    def get_loop_rate(self):
+    def get_loop_rate(self) -> float:
         """Get the current main loop rate (pause per iteration)"""
         return self.loop_rate
 
-    def set_codec_profile(self, profile):
+    def set_codec_profile(self, profile: str) -> None:
         """set the audio profile"""
         if profile in ["audio", "voip", "restricted_lowdelay"]:
             self.__opus_profile = profile
         else:
             raise ValueError("Unknown profile: " + str(profile))
 
-    def get_codec_profile(self):
+    def get_codec_profile(self) -> str:
         """return the audio profile string"""
         return self.__opus_profile
 
-    def set_receive_sound(self, value):
+    def set_receive_sound(self, value: bool) -> None:
         """Enable or disable the management of incoming sounds"""
         if value:
             self.receive_sound = True
         else:
             self.receive_sound = False
 
-    def is_ready(self):
+    def is_ready(self) -> None:
         """Wait for the connection to be fully completed.  To be used in the main thread"""
         self.ready_lock.acquire()
         self.ready_lock.release()
 
-    def execute_command(self, cmd, blocking=True):
+    def execute_command(self, cmd: Any, blocking: bool = True) -> Any:
         """Create a command to be sent to the server.  To be used in the main thread"""
         self.is_ready()
 
@@ -628,7 +629,7 @@ class Mumble(threading.Thread):
     # TODO: manage a timeout for blocking commands.  Currently, no command actually waits for the server to execute
     # The result of these commands should actually be checked against incoming server updates
 
-    def treat_command(self, cmd):
+    def treat_command(self, cmd: Any) -> None:
         """Send the awaiting commands to the server.  Used in the pymumble thread."""
         if cmd.cmd == PYMUMBLE_CMD_MOVE:
             userstate = mumble_pb2.UserState()
@@ -798,19 +799,19 @@ class Mumble(threading.Thread):
             cmd.response = True
             self.commands.answer(cmd)
 
-    def get_max_message_length(self):
+    def get_max_message_length(self) -> int:
         return self.server_max_message_length
 
-    def get_max_image_length(self):
+    def get_max_image_length(self) -> int:
         return self.server_max_image_message_length
 
-    def my_channel(self):
+    def my_channel(self) -> dict[str, Any]:
         return self.channels[self.users.myself["channel_id"]]
 
-    def denial_type(self, n):
+    def denial_type(self, n: int) -> str:
         return mumble_pb2.PermissionDenied.DenyType.Name(n)
 
-    def stop(self):
+    def stop(self) -> None:
         self.reconnect = None
         self.exit = True
         self.control_socket.close()

--- a/src/pymumble_py3/tools.py
+++ b/src/pymumble_py3/tools.py
@@ -8,10 +8,10 @@ class InvalidVarInt(Exception):
 
 class VarInt:
     """Implement the varint type used in mumble"""
-    def __init__(self, value=0):
+    def __init__(self, value: int = 0) -> None:
         self.value = value
-        
-    def encode(self):
+
+    def encode(self) -> bytes:
         """Encode an integer in the VarInt format, returning a binary string"""
         result = bytearray()
         value = abs(self.value)
@@ -35,7 +35,7 @@ class VarInt:
         else:
             return result + struct.pack("!BQ", 0b11110100, value)
 
-    def decode(self, value):
+    def decode(self, value: bytes) -> int:
         """Decode a VarInt contained in a binary string, returning an integer"""
         varint = value
         is_negative = False
@@ -102,7 +102,7 @@ class VarInt:
         return size
 
 
-def tohex(buffer):
+def tohex(buffer: bytes) -> str:
     """Used for debugging.  Output a sting in hex format"""
     result = "\n"
     cpt1 = 0

--- a/src/pymumble_py3/users.py
+++ b/src/pymumble_py3/users.py
@@ -36,7 +36,7 @@ class Users(dict):
 
         self.lock.release()
 
-    def remove(self, message):
+    def remove(self, message: Any) -> None:
         """Remove a user object based on server info"""
         self.lock.acquire()
 
@@ -47,13 +47,13 @@ class Users(dict):
 
         self.lock.release()
 
-    def set_myself(self, session):
+    def set_myself(self, session: int) -> None:
         """Set the "myself" user"""
         self.myself_session = session
         if session in self:
             self.myself = self[session]
 
-    def count(self):
+    def count(self) -> int:
         """Return the count of connected users"""
         return len(self)
 
@@ -113,7 +113,7 @@ class User(dict):
         else:
             return None
 
-    def mute(self):
+    def mute(self) -> None:
         """Mute a user"""
         params = {"session": self["session"]}
 
@@ -125,7 +125,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def unmute(self):
+    def unmute(self) -> None:
         """Unmute a user"""
         params = {"session": self["session"]}
 
@@ -137,7 +137,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def deafen(self):
+    def deafen(self) -> None:
         """Deafen a user"""
         params = {"session": self["session"]}
 
@@ -149,7 +149,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def undeafen(self):
+    def undeafen(self) -> None:
         """Undeafen a user"""
         params = {"session": self["session"]}
 
@@ -161,7 +161,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def suppress(self):
+    def suppress(self) -> None:
         """Disable a user"""
         params = {"session": self["session"],
                   "suppress": True}
@@ -169,7 +169,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def unsuppress(self):
+    def unsuppress(self) -> None:
         """Enable a user"""
         params = {"session": self["session"],
                   "suppress": False}
@@ -177,7 +177,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def recording(self):
+    def recording(self) -> None:
         """Set the user as recording"""
         params = {"session": self["session"],
                   "recording": True}
@@ -185,7 +185,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def unrecording(self):
+    def unrecording(self) -> None:
         """Set the user as not recording"""
         params = {"session": self["session"],
                   "recording": False}
@@ -193,7 +193,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def comment(self, comment):
+    def comment(self, comment: str) -> None:
         """Set the user comment"""
         params = {"session": self["session"],
                   "comment": comment}
@@ -201,7 +201,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def texture(self, texture):
+    def texture(self, texture: bytes) -> None:
         """Set the user texture"""
         params = {"session": self["session"],
                   "texture": texture}
@@ -209,7 +209,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
     
-    def register(self):
+    def register(self) -> None:
         """Register the user (mostly for myself)"""
         params = {"session": self["session"],
                   "user_id": 0}
@@ -217,13 +217,13 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def update_context(self, context_name):
+    def update_context(self, context_name: str) -> None:
         params = {"session": self["session"],
                   "plugin_context": context_name}
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def move_in(self, channel_id, token=None):
+    def move_in(self, channel_id: int, token: str | None = None) -> None:
         if token:
             authenticate = mumble_pb2.Authenticate()
             authenticate.username = self.mumble_object.user
@@ -238,7 +238,7 @@ class User(dict):
         cmd = messages.MoveCmd(session, channel_id)
         self.mumble_object.execute_command(cmd)
 
-    def send_text_message(self, message):
+    def send_text_message(self, message: str) -> None:
         """Send a text message to the user."""
 
         # TODO: This check should be done inside execute_command()
@@ -254,7 +254,7 @@ class User(dict):
         cmd = messages.TextPrivateMessage(self["session"], message)
         self.mumble_object.execute_command(cmd)
 
-    def kick(self, reason=""):
+    def kick(self, reason: str = "") -> None:
         params = {"session": self["session"],
                   "reason": reason,
                   "ban": False}
@@ -262,7 +262,7 @@ class User(dict):
         cmd = messages.RemoveUser(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def ban(self, reason=""):
+    def ban(self, reason: str = "") -> None:
         params = {"session": self["session"],
                   "reason": reason,
                   "ban": True}
@@ -270,7 +270,7 @@ class User(dict):
         cmd = messages.RemoveUser(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def add_listening_channels(self, channel):
+    def add_listening_channels(self, channel: int) -> None:
         """Add user to listening channel"""
         params = {"session": self["session"],
                   "listening_channel_add": channel}
@@ -278,7 +278,7 @@ class User(dict):
         cmd = messages.ModUserState(self.mumble_object.users.myself_session, params)
         self.mumble_object.execute_command(cmd)
 
-    def remove_listening_channels(self, channel):
+    def remove_listening_channels(self, channel: int) -> None:
         """Remove user from listening channel"""
         params = {"session": self["session"],
                   "listening_channel_remove": channel}


### PR DESCRIPTION
Complete the type annotation pass: annotate all remaining methods in users.py, channels.py, blobs.py, callbacks.py, errors.py, messages.py, tools.py, and the Mumble class in mumble.py; also fill the missing annotations in command.py and interface.py.