### PR TITLE
Set up QEMU for Docker multi-platform support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,7 +56,10 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-        
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
       
@@ -64,6 +67,7 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         file: ./Dockerfile
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,8 +31,18 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
     needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - name: Checkout
@@ -44,6 +54,54 @@ jobs:
         username: ${{ vars.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build and push Docker image
+      id: build
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        platforms: ${{ matrix.platform }}
+        file: ./Dockerfile
+        outputs: type=image,name=${{ vars.DOCKER_USERNAME }}/botamusique,push-by-digest=true,name-canonical=true,push=true
+        build-args: GIT_COMMIT=${{ github.sha }}
+        provenance: true
+        sbom: true
+
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      uses: actions/upload-artifact@v7
+      with:
+        name: digests-${{ matrix.artifact }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge:
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v7
+      with:
+        path: /tmp/digests
+        pattern: digests-*
+        merge-multiple: true
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ vars.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
     - name: Extract Docker image metadata
       id: meta
       uses: docker/metadata-action@v6
@@ -57,24 +115,15 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
-      
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v7
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        file: ./Dockerfile
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-        annotations: ${{ steps.meta.outputs.annotations }}
-        build-args: GIT_COMMIT=${{ github.sha }}
-        provenance: true
-        sbom: true
+
+    - name: Create multi-platform manifest
+      working-directory: /tmp/digests
+      run: |
+        docker buildx imagetools create \
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ vars.DOCKER_USERNAME }}/botamusique@sha256:%s ' *)
 
   publish-release:
 

--- a/.github/workflows/docker-pr-check.yml
+++ b/.github/workflows/docker-pr-check.yml
@@ -40,6 +40,9 @@ jobs:
         tags: |
           type=ref,event=pr
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+  
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -47,6 +50,7 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: .
+        platforms: linux/amd64,linux/arm64
         file: ./Dockerfile
         push: false
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-pr-check.yml
+++ b/.github/workflows/docker-pr-check.yml
@@ -41,7 +41,7 @@ jobs:
           type=ref,event=pr
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
   
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
@@ -54,3 +54,4 @@ jobs:
         file: ./Dockerfile
         push: false
         tags: ${{ steps.meta.outputs.tags }}
+  

--- a/.github/workflows/docker-pr-check.yml
+++ b/.github/workflows/docker-pr-check.yml
@@ -25,8 +25,16 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-latest
     needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - name: Checkout
@@ -40,9 +48,6 @@ jobs:
         tags: |
           type=ref,event=pr
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
-  
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
@@ -50,8 +55,7 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ matrix.platform }}
         file: ./Dockerfile
         push: false
         tags: ${{ steps.meta.outputs.tags }}
-  


### PR DESCRIPTION
Added QEMU setup for multi-platform builds. This would publish docker image for both linux/amd64 and linux/arm64.

I could not confirm the main job succeeds properly as I don't have the dockerhub setup but the PR check job should succeed (it succeeded [here](https://github.com/gplassard/botamusique/actions/runs/26974854000/job/79603799744))